### PR TITLE
Fix output directory creation

### DIFF
--- a/src/playoff_draft.py
+++ b/src/playoff_draft.py
@@ -55,6 +55,8 @@ def get_players(teams: list[Team]) -> list[Player]:
 
 
 def write_results(teams: list[Team], players: list[Player], output_dir: str):
+    os.makedirs(output_dir, exist_ok=True)
+
     write_teams_to_csv(teams, os.path.join(output_dir, "teams.tsv"))
 
     write_players_to_csv(players, os.path.join(output_dir, "all.tsv"))


### PR DESCRIPTION
## Summary
- ensure output directory exists before attempting to write results

## Testing
- `python -m py_compile src/player.py src/team.py src/heuristics.py src/playoff_draft.py`
- `python src/playoff_draft.py`

------
https://chatgpt.com/codex/tasks/task_e_6865649e7e488329bdfb690f89166abd