### PR TITLE
Refactor pipeline: add config, loader, scoring, models, optimizer, reporting, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,241 @@
-# nhl-playoff-drafter
- 
+# NHL Playoff Drafter
+
+A data-driven playoff fantasy drafting tool for NHL skaters and goalie **teams**.
+
+This project currently provides:
+- TSV-based data loading with validation/diagnostics,
+- heuristic team/player valuation,
+- typed projection contracts and scoring helpers,
+- lineup optimization skeleton (5F / 3D / 2 goalie teams),
+- ranked output exports for downstream draft decisions.
+
+---
+
+## Table of Contents
+
+- [What this tool does](#what-this-tool-does)
+- [Current scoring/roster assumptions](#current-scoringroster-assumptions)
+- [Repository structure](#repository-structure)
+- [Architecture overview](#architecture-overview)
+- [Data inputs](#data-inputs)
+- [How to run](#how-to-run)
+- [Outputs](#outputs)
+- [Testing](#testing)
+- [Development workflow](#development-workflow)
+- [Troubleshooting](#troubleshooting)
+- [Roadmap](#roadmap)
+
+---
+
+## What this tool does
+
+At a high level, the pipeline:
+1. Loads and validates team/player TSV data.
+2. Joins season/stretch/previous-season player rows by `(Name, Team)`.
+3. Computes team-level heuristic values.
+4. Computes player heuristic values.
+5. Builds typed projection inputs and projected values.
+6. Selects a lineup under roster constraints.
+7. Writes ranked TSV outputs to `out/season_2026`.
+
+The current optimizer is intentionally simple (greedy by projected value) and is planned to be replaced by a constrained optimization model in a follow-up phase.
+
+---
+
+## Current scoring/roster assumptions
+
+### Scoring
+- **Skaters**
+  - Goal = 1
+  - Assist = 1
+  - OT goal bonus = +1 (OT goals effectively count as 2 total)
+- **Goalie teams**
+  - Win = 1
+  - Goalie assist = 1
+  - Shutout = 5
+
+### Roster constraints
+- 5 Forwards
+- 3 Defense
+- 2 Goalie teams
+
+Defaults are defined in `src/config.py` and used throughout the pipeline.
+
+---
+
+## Repository structure
+
+```text
+.
+├── docs/
+│   └── heuristics_implementation_plan.md
+├── resources/
+│   ├── 2024/
+│   ├── 2025/
+│   └── 2026/
+├── src/
+│   ├── config.py
+│   ├── contracts.py
+│   ├── data_loader.py
+│   ├── heuristics.py
+│   ├── models.py
+│   ├── optimizer.py
+│   ├── player.py
+│   ├── playoff_draft.py
+│   ├── reporting.py
+│   ├── scoring.py
+│   └── team.py
+├── tests/
+│   ├── test_config.py
+│   └── test_data_loader.py
+└── README.md
+```
+
+---
+
+## Architecture overview
+
+### `src/playoff_draft.py` (orchestration)
+Entry point that wires the pipeline end-to-end:
+- load data,
+- apply heuristics,
+- project skaters/goalie teams,
+- optimize lineup,
+- write outputs,
+- print diagnostics.
+
+### `src/config.py`
+Central location for:
+- scoring constants,
+- roster constraints,
+- path/file constants,
+- model tuning defaults (e.g., stretch shrinkage constant).
+
+### `src/data_loader.py`
+Responsible for ingesting TSV inputs and producing structured objects:
+- validates required columns,
+- joins players by `(Name, Team)`,
+- tracks load diagnostics (`loaded`, `skipped`, reasons),
+- supports `strict` mode (fail on row drops),
+- exposes typed conversion helpers for modeling.
+
+### `src/contracts.py`
+Typed dataclasses used to pass model inputs between modules.
+
+### `src/scoring.py`
+Pure, test-friendly scoring functions:
+- skater score from raw or summary stats,
+- goalie-team score,
+- per-game rate,
+- season/stretch blending.
+
+### `src/models.py`
+Projection layer that transforms typed inputs + expected team games into projected values.
+
+### `src/optimizer.py`
+Lineup selection module. Current implementation is deterministic greedy top-N by position, constrained by roster slots.
+
+### `src/reporting.py`
+Output writers for ranked team and skater TSV files.
+
+### `src/heuristics.py`
+Legacy and current heuristic functions for team/player estimated values.
+
+---
+
+## Data inputs
+
+Input files are expected under `resources/2026` by default:
+- `teams.tsv`
+- `players_season.tsv`
+- `players_stretch.tsv`
+- `players_prev_season.tsv`
+
+> Important: input format is intentionally preserved; the project assumes existing TSV schemas and tab delimiters.
+
+If required columns are missing, loading fails early with an explicit error.
+
+---
+
+## How to run
+
+From repository root:
+
+```bash
+python src/playoff_draft.py
+```
+
+Expected terminal output includes:
+- loader diagnostics summary,
+- optimized lineup slot counts,
+- `SUCCESS` on completion.
+
+---
+
+## Outputs
+
+Generated under `out/season_2026/`:
+- `teams.tsv`
+- `all.tsv`
+- `forwards.tsv`
+- `defense.tsv`
+
+`all.tsv` contains full ranked skater output; forwards/defense are split filtered views.
+
+---
+
+## Testing
+
+Run all current unit tests:
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py'
+```
+
+Current test coverage includes:
+- config defaults (`tests/test_config.py`),
+- data loader validation and strict-mode behavior (`tests/test_data_loader.py`).
+
+---
+
+## Development workflow
+
+### Branch strategy
+This project uses stacked branches with the `codex/improveHeuristics/*` convention. See `docs/heuristics_implementation_plan.md` for current phase ordering.
+
+### Coding guidance
+- Keep modules focused on single responsibilities.
+- Prefer typed contracts over unstructured dict passing between pipeline stages.
+- Keep scoring/model functions pure where possible for easier testing.
+- Do not change resource input formats unless explicitly requested.
+
+### Adding dependencies
+Only add widely supported libraries. If you add any package, include/update `requirements.txt`.
+
+---
+
+## Troubleshooting
+
+### `ValueError: File <name> missing required columns`
+Your TSV schema does not contain required fields. Compare against expected columns in `DataLoader.REQUIRED_*_COLUMNS`.
+
+### Fewer players than expected in outputs
+Check loader diagnostics printed by the main script. Common reasons:
+- no stretch row match,
+- team code mismatch between players and teams files.
+
+### Strict mode failures
+If `strict=True` is enabled in `DataLoader`, any skipped rows raise an error by design.
+
+---
+
+## Roadmap
+
+See the detailed implementation roadmap in:
+- `docs/heuristics_implementation_plan.md`
+
+Near-term planned upgrades:
+- formal expected-games model (analytic + Monte Carlo),
+- stronger optimizer (ILP/OR tools),
+- richer goalie-team projections with actual goalie-team rate inputs,
+- backtesting harness and calibration.

--- a/docs/heuristics_implementation_plan.md
+++ b/docs/heuristics_implementation_plan.md
@@ -1,0 +1,311 @@
+# NHL Playoff Drafter — Detailed Heuristics Implementation Plan
+
+Date: 2026-04-17
+
+This plan is intentionally implementation-level (file-by-file, function-by-function), not just conceptual.
+
+---
+
+## Constraints and non-goals
+
+- **Do not change input resource format** in `resources/*/*.tsv` (column names and delimiter remain as-is).
+- Preserve current CLI usage: `python src/playoff_draft.py` should still work.
+- Backward compatibility target: existing output files (`all.tsv`, `forwards.tsv`, `defense.tsv`, `teams.tsv`) continue to be produced.
+- Optional external libraries are allowed **only** if broadly trusted and maintained; if used, add `requirements.txt`.
+
+---
+
+## 1) Cleanup + architecture prep (first task)
+
+### Objective
+Create a stable foundation so scoring/model/optimizer changes can be added without repeatedly editing I/O glue code.
+
+### Implementation details
+
+#### 1.1 Module boundaries
+Create/standardize the following modules and responsibilities:
+
+- `src/config.py`
+  - scoring constants (skater + goalie-team)
+  - roster constraints (5F/3D/2G-team)
+  - dataset + output paths
+- `src/data_loader.py`
+  - TSV read helpers
+  - required-column validation
+  - keyed joins by `(Name, Team)`
+  - load diagnostics (matched/missing counts)
+- `src/scoring.py` (new)
+  - pure stat-to-fantasy conversion functions
+  - no file or global I/O
+- `src/models.py` (new)
+  - expected-games estimators
+  - skater and goalie-team EV models
+- `src/optimizer.py` (new)
+  - lineup optimizer with exact roster constraints
+- `src/reporting.py` (new)
+  - output writers and ranking/lineup tables
+- `src/playoff_draft.py`
+  - orchestration only (load -> model -> optimize -> write)
+
+#### 1.2 Data contracts
+Define typed intermediate records (dataclass or TypedDict) so modules pass structured objects instead of raw dicts.
+
+- `SkaterProjectionInput`
+  - `name`, `team`, `position`, `season_gp`, `season_p`, `season_otg`, `stretch_gp`, `stretch_p`, `stretch_otg`, optional prior-season equivalents
+- `GoalieTeamProjectionInput`
+  - `team`, `season_wins`, `season_goaltender_assists`, `season_shutouts`, `team_odds`
+- `TeamOddsInput`
+  - `team`, `round1`, `round2`, `conference`, `final`
+
+#### 1.3 Validation behavior
+- Hard-fail on missing required columns.
+- Soft-warn and skip rows when numeric parsing fails.
+- Emit summary diagnostics:
+  - loaded row counts
+  - matched skaters
+  - unmatched by reason (`no_stretch_match`, `no_team_match`, etc.)
+
+#### 1.4 Test scaffolding
+Add:
+- `tests/test_data_loader.py`
+  - required-column failures
+  - join correctness for duplicate names on different teams
+- `tests/test_config.py`
+  - scoring and roster defaults
+
+### Acceptance criteria
+- Main script still runs with unchanged resources.
+- Join logic is keyed (no nested O(n^3) loops).
+- Data loader emits deterministic counts for matched/unmatched rows.
+
+---
+
+## 2) Formal scoring model layer
+
+### Objective
+Encode your exact league scoring rules as explicit formulas.
+
+### Scoring rules to implement
+- Skaters: `1*G + 1*A + 1*OTG_bonus`
+  - Equivalent in aggregate: `P + OTG`
+- Goalie teams: `1*W + 1*GoalieAssists + 5*SO`
+
+### Implementation details
+
+#### 2.1 `src/scoring.py`
+Implement pure helpers:
+
+- `skater_points_raw(goals, assists, ot_goals) -> float`
+- `skater_points_from_summary(points, ot_goals) -> float`  
+  (used when only `P` and `OTG` are present)
+- `goalie_team_points_raw(wins, assists, shutouts) -> float`
+- `rate_per_game(total_points, games_played) -> float`
+- `blend_rates(season_rate, stretch_rate, stretch_gp, k) -> float`
+
+#### 2.2 Parameterization
+Expose tunables in config:
+- `STRETCH_SHRINKAGE_K` (default `20`)
+- `MIN_STRETCH_GP_FOR_DIRECT_WEIGHT` (default `10`)
+
+#### 2.3 Unit tests
+- exact formula checks for representative rows
+- edge cases: `GP=0`, missing OTG, small stretch sample
+
+### Acceptance criteria
+- All scoring math is implemented in one module.
+- No heuristic function hard-codes raw multipliers directly in orchestration code.
+
+---
+
+## 3) Expected playoff games model
+
+### Objective
+Replace ad hoc team multipliers with explicit expected games per team.
+
+### Implementation details
+
+#### 3.1 Analytic estimator (`src/models.py`)
+Given cumulative advancement probabilities (`R1`, `R2`, `CF`, `F`), compute:
+
+- independent round probs:
+  - `p1 = R1`
+  - `p2 = R2 / R1` (if `R1>0` else 0)
+  - `p3 = CF / R2` (if `R2>0` else 0)
+  - `p4 = F / CF` (if `CF>0` else 0)
+- expected games:
+  - baseline appearance in round 1 plus continuation expectation
+  - use configurable expected series length constants (`E_LEN_R1..R4`, default `5.9` each)
+
+#### 3.2 Monte Carlo estimator (`src/models.py`)
+- run `N` simulations (default `20_000`)
+- for each round, sample advance with independent round probs
+- sample series length from empirical discrete distribution over `{4,5,6,7}`
+- record team game totals, return mean/std/p10/p90
+
+#### 3.3 Model selector
+- config key: `EXPECTED_GAMES_METHOD = "analytic" | "monte_carlo"`
+- fallback to analytic if Monte Carlo fails
+
+#### 3.4 Tests
+- sanity: stronger teams have higher expected games
+- monotonicity checks when probabilities increase
+
+### Acceptance criteria
+- Team EV uses expected games rather than raw summed odds.
+- Both methods available behind config flag.
+
+---
+
+## 4) Roster optimizer (5F / 3D / 2 goalie teams)
+
+### Objective
+Generate an actual best lineup under hard roster constraints.
+
+### Implementation details
+
+#### 4.1 Dependency decision
+Preferred first choice: `pulp` (widely used, simple LP API).  
+If added, include `requirements.txt` with pinned major versions.
+
+#### 4.2 `src/optimizer.py`
+Implement:
+- `optimize_lineup(forwards, defense, goalie_teams, constraints, risk_lambda=0.0)`
+- binary decision vars per candidate
+- hard constraints:
+  - exactly 5 forwards
+  - exactly 3 defense
+  - exactly 2 goalie teams
+- optional constraints:
+  - `max_skaters_per_team`
+  - `max_total_from_team_including_goalie_team`
+
+Objective:
+- default: maximize expected points
+- optional risk-adjusted objective: maximize `E - lambda*SD`
+
+#### 4.3 Tests
+- constraint satisfaction always exact
+- deterministic output on fixed toy data
+- tie-breaking deterministic by stable key sort
+
+### Acceptance criteria
+- Produces one valid optimal lineup and objective value.
+- Can emit top-N alternative lineups by exclusion constraints (optional).
+
+---
+
+## 5) Data reliability + quality diagnostics
+
+### Objective
+Harden ingest/projection pipeline and make data issues visible.
+
+### Implementation details
+
+- Add explicit parse helpers with contextual errors (`file`, `row`, `column`).
+- Track per-file null/missing counts for critical fields (`GP`, `P`, `OTG`, odds columns).
+- Add `--strict` mode:
+  - strict: fail on any dropped row
+  - default: continue with warning and report
+- Write diagnostics report to `out/season_2026/diagnostics.tsv`.
+
+### Tests
+- parser behavior in strict vs non-strict mode
+- diagnostics output shape and counts
+
+### Acceptance criteria
+- Every dropped row is accounted for with a reason code.
+- Pipeline behavior is predictable under malformed data.
+
+---
+
+## 6) Backtesting + calibration harness
+
+### Objective
+Quantify whether new heuristics outperform the baseline.
+
+### Implementation details
+
+#### 6.1 Script
+Add `scripts/backtest.py` with args:
+- `--seasons 2024 2025`
+- `--method analytic|monte_carlo`
+- `--k-values 10 20 30`
+- `--risk-lambda-grid 0 0.1 0.2`
+
+#### 6.2 Workflow
+For each season:
+1. load historical input snapshot
+2. generate projections
+3. build optimized lineup
+4. compare against realized playoff fantasy points
+
+#### 6.3 Metrics
+- Spearman rank correlation (overall and by position)
+- Top-K precision/recall by position
+- MAE/RMSE for projected vs realized points
+- lineup realized points vs baseline lineup
+
+#### 6.4 Outputs
+- `out/backtest/summary.tsv`
+- `out/backtest/season_<year>_details.tsv`
+- optional markdown summary report
+
+### Acceptance criteria
+- Reproducible backtest command.
+- At least two metrics improve vs existing baseline.
+
+---
+
+## 7) Reporting outputs for draft decisions
+
+### Objective
+Make outputs decision-ready for actual drafting.
+
+### Implementation details
+
+#### 7.1 Ranking exports
+- `forwards.tsv`: rank, EV, floor/ceiling, key rates
+- `defense.tsv`: same fields
+- `goalie_teams.tsv`: EV breakdown (`W`, `A`, `SO`, expected games)
+
+#### 7.2 Lineup exports
+- `optimal_lineup.tsv`
+- `alternative_lineups.tsv` (high-floor and high-ceiling variants)
+- `team_exposure.tsv` (selected shares by NHL team)
+
+#### 7.3 Explainability fields
+For each candidate include:
+- contribution breakdown (`team_games_factor`, `rate_factor`, shrinkage weight)
+- confidence band from MC or proxy variance
+
+### Acceptance criteria
+- Outputs clearly explain why each pick is ranked.
+- One-command run produces all artifacts.
+
+---
+
+## Sequential stacked-branch workflow (no Graphite; branch prefix `codex/improveHeuristics/`)
+
+Each task ships on its own branch, each branch based on previous branch head.
+
+1. `codex/improveHeuristics/initialCleanup` (current branch for cleanup + plan)
+2. `codex/improveHeuristics/scoring-model` (base: `codex/improveHeuristics/initialCleanup`)
+3. `codex/improveHeuristics/expected-games` (base: `codex/improveHeuristics/scoring-model`)
+4. `codex/improveHeuristics/optimizer` (base: `codex/improveHeuristics/expected-games`)
+5. `codex/improveHeuristics/data-reliability` (base: `codex/improveHeuristics/optimizer`)
+6. `codex/improveHeuristics/backtesting` (base: `codex/improveHeuristics/data-reliability`)
+7. `codex/improveHeuristics/reporting` (base: `codex/improveHeuristics/backtesting`)
+
+### Per-branch execution checklist
+- Implement only scoped files/functions for the branch.
+- Add/adjust tests for that scope.
+- Run:
+  - `python src/playoff_draft.py`
+  - `pytest` (once tests are added)
+- Commit with phase-specific message.
+- Open PR targeting previous stack branch.
+- Rebase/retarget open stack PRs after merges.
+
+### Merge policy
+- Merge only when branch acceptance criteria are satisfied.
+- Do not start next phase code until previous phase CI is green.

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ScoringConfig:
+    skater_goal: int = 1
+    skater_assist: int = 1
+    skater_ot_goal_bonus: int = 1
+    goalie_win: int = 1
+    goalie_assist: int = 1
+    goalie_shutout: int = 5
+
+
+@dataclass(frozen=True)
+class RosterConfig:
+    forwards: int = 5
+    defense: int = 3
+    goalie_teams: int = 2
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+RESOURCES_DIR = ROOT_DIR / "resources" / "2026"
+OUTPUT_DIR = ROOT_DIR / "out" / "season_2026"
+
+PLAYER_SEASON_FILE = "players_season.tsv"
+PLAYER_STRETCH_FILE = "players_stretch.tsv"
+PLAYER_PREV_SEASON_FILE = "players_prev_season.tsv"
+TEAM_FILE = "teams.tsv"
+
+SCORING = ScoringConfig()
+ROSTER = RosterConfig()
+
+STRETCH_SHRINKAGE_K = 20
+DEFAULT_EXPECTED_TEAM_GAMES = 6.0

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TeamOddsInput:
+    team: str
+    round1: float
+    round2: float
+    conference: float
+    final: float
+
+
+@dataclass(frozen=True)
+class SkaterProjectionInput:
+    name: str
+    team: str
+    position: str
+    season_gp: int
+    season_p: int
+    season_otg: int
+    stretch_gp: int
+    stretch_p: int
+    stretch_otg: int
+    prior_gp: int = 0
+    prior_p: int = 0
+    prior_otg: int = 0
+
+
+@dataclass(frozen=True)
+class GoalieTeamProjectionInput:
+    team: str
+    season_wins: int
+    season_goaltender_assists: int
+    season_shutouts: int
+    team_odds: TeamOddsInput

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,0 +1,173 @@
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from contracts import GoalieTeamProjectionInput, SkaterProjectionInput, TeamOddsInput
+from player import Player
+from team import Team
+
+
+@dataclass(frozen=True)
+class ResourceFiles:
+    teams_file: str
+    player_season_file: str
+    player_stretch_file: str
+    player_prev_season_file: str
+
+
+@dataclass
+class LoadDiagnostics:
+    season_rows: int = 0
+    stretch_rows: int = 0
+    prev_rows: int = 0
+    team_rows: int = 0
+    players_loaded: int = 0
+    skipped_missing_stretch: int = 0
+    skipped_missing_team: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+class DataLoader:
+    REQUIRED_TEAM_COLUMNS = {"Name", "Round1", "Round2", "Conference", "Final"}
+    REQUIRED_PLAYER_COLUMNS = {"Name", "Team", "Pos", "GP", "P"}
+
+    def __init__(self, resources_dir: Path, resource_files: ResourceFiles, strict: bool = False):
+        self.resources_dir = Path(resources_dir)
+        self.resource_files = resource_files
+        self.strict = strict
+        self.diagnostics = LoadDiagnostics()
+
+    def load_teams(self) -> list[Team]:
+        teams_data = self._read_tsv(self.resource_files.teams_file)
+        self.diagnostics.team_rows = len(teams_data)
+        self._validate_columns(self.resource_files.teams_file, teams_data, self.REQUIRED_TEAM_COLUMNS)
+        return [Team(row) for row in teams_data]
+
+    def load_players(self, teams: list[Team]) -> list[Player]:
+        season_rows = self._read_tsv(self.resource_files.player_season_file)
+        stretch_rows = self._read_tsv(self.resource_files.player_stretch_file)
+        prev_rows = self._read_tsv(self.resource_files.player_prev_season_file)
+
+        self.diagnostics.season_rows = len(season_rows)
+        self.diagnostics.stretch_rows = len(stretch_rows)
+        self.diagnostics.prev_rows = len(prev_rows)
+
+        self._validate_columns(self.resource_files.player_season_file, season_rows, self.REQUIRED_PLAYER_COLUMNS)
+        self._validate_columns(self.resource_files.player_stretch_file, stretch_rows, self.REQUIRED_PLAYER_COLUMNS)
+
+        teams_by_name = {team.name: team for team in teams}
+        stretch_by_key = self._index_by_player_key(stretch_rows)
+        prev_by_key = self._index_by_player_key(prev_rows)
+
+        players: list[Player] = []
+        for season in season_rows:
+            key = self._player_key(season)
+            stretch = stretch_by_key.get(key)
+            team = teams_by_name.get(season.get("Team", ""))
+            if stretch is None:
+                self.diagnostics.skipped_missing_stretch += 1
+                continue
+            if team is None:
+                self.diagnostics.skipped_missing_team += 1
+                continue
+
+            prev = prev_by_key.get(key, {})
+            players.append(Player(team, season, stretch, prev))
+
+        self.diagnostics.players_loaded = len(players)
+        self._finalize_diagnostics()
+        return players
+
+
+    def to_skater_projection_inputs(self, players: list[Player]) -> list[SkaterProjectionInput]:
+        results: list[SkaterProjectionInput] = []
+        for player in players:
+            results.append(
+                SkaterProjectionInput(
+                    name=player.name,
+                    team=player.team.name,
+                    position=player.position,
+                    season_gp=player.seasonStats.games_played,
+                    season_p=player.seasonStats.points,
+                    season_otg=player.seasonStats.overtime_goals,
+                    stretch_gp=player.stretchStats.games_played,
+                    stretch_p=player.stretchStats.points,
+                    stretch_otg=player.stretchStats.overtime_goals,
+                    prior_gp=player.prevSeasonStats.games_played,
+                    prior_p=player.prevSeasonStats.points,
+                    prior_otg=player.prevSeasonStats.overtime_goals,
+                )
+            )
+        return results
+
+    def to_team_odds_inputs(self, teams: list[Team]) -> list[TeamOddsInput]:
+        return [
+            TeamOddsInput(
+                team=team.name,
+                round1=team.odds.round1,
+                round2=team.odds.round2,
+                conference=team.odds.conference,
+                final=team.odds.final,
+            )
+            for team in teams
+        ]
+
+    def to_goalie_team_projection_inputs(self, teams: list[Team]) -> list[GoalieTeamProjectionInput]:
+        team_odds = {item.team: item for item in self.to_team_odds_inputs(teams)}
+        return [
+            GoalieTeamProjectionInput(
+                team=team.name,
+                season_wins=0,
+                season_goaltender_assists=0,
+                season_shutouts=0,
+                team_odds=team_odds[team.name],
+            )
+            for team in teams
+        ]
+
+    def _read_tsv(self, filename: str) -> list[dict[str, str]]:
+        file_path = self.resources_dir / filename
+        with open(file_path, mode="r", newline="", encoding="utf-8") as file_handle:
+            return list(csv.DictReader(file_handle, delimiter="\t"))
+
+    @staticmethod
+    def _validate_columns(filename: str, rows: list[dict[str, str]], required: set[str]):
+        if not rows:
+            raise ValueError(f"File {filename} is empty")
+
+        missing = required - set(rows[0].keys())
+        if missing:
+            missing_list = ", ".join(sorted(missing))
+            raise ValueError(f"File {filename} missing required columns: {missing_list}")
+
+    @staticmethod
+    def _player_key(row: dict[str, str]) -> tuple[str, str]:
+        return row.get("Name", ""), row.get("Team", "")
+
+    def _index_by_player_key(self, rows: list[dict[str, str]]) -> dict[tuple[str, str], dict[str, str]]:
+        return {self._player_key(row): row for row in rows}
+
+    def _finalize_diagnostics(self) -> None:
+        if self.diagnostics.skipped_missing_stretch:
+            self.diagnostics.warnings.append(
+                f"Skipped {self.diagnostics.skipped_missing_stretch} players with no stretch row match"
+            )
+        if self.diagnostics.skipped_missing_team:
+            self.diagnostics.warnings.append(
+                f"Skipped {self.diagnostics.skipped_missing_team} players with no known team"
+            )
+
+        if self.strict and (self.diagnostics.skipped_missing_stretch or self.diagnostics.skipped_missing_team):
+            joined = "; ".join(self.diagnostics.warnings)
+            raise ValueError(f"Strict mode enabled, dropped players during load: {joined}")
+
+    def diagnostics_summary(self) -> str:
+        summary = (
+            f"loaded players={self.diagnostics.players_loaded} "
+            f"from season={self.diagnostics.season_rows}, "
+            f"stretch={self.diagnostics.stretch_rows}, "
+            f"prev={self.diagnostics.prev_rows}; "
+            f"skipped_missing_stretch={self.diagnostics.skipped_missing_stretch}, "
+            f"skipped_missing_team={self.diagnostics.skipped_missing_team}"
+        )
+        return summary

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from config import STRETCH_SHRINKAGE_K
+from contracts import GoalieTeamProjectionInput, SkaterProjectionInput
+from scoring import blend_rates, goalie_team_points_raw, rate_per_game, skater_points_from_summary
+
+
+@dataclass(frozen=True)
+class SkaterProjection:
+    name: str
+    team: str
+    position: str
+    expected_points: float
+
+
+@dataclass(frozen=True)
+class GoalieTeamProjection:
+    team: str
+    expected_points: float
+
+
+def project_skaters(inputs: list[SkaterProjectionInput], expected_team_games: dict[str, float]) -> list[SkaterProjection]:
+    projections: list[SkaterProjection] = []
+    for item in inputs:
+        season_rate = rate_per_game(skater_points_from_summary(item.season_p, item.season_otg), item.season_gp)
+        stretch_rate = rate_per_game(skater_points_from_summary(item.stretch_p, item.stretch_otg), item.stretch_gp)
+        blended_rate = blend_rates(season_rate, stretch_rate, item.stretch_gp, STRETCH_SHRINKAGE_K)
+        projections.append(
+            SkaterProjection(
+                name=item.name,
+                team=item.team,
+                position=item.position,
+                expected_points=blended_rate * expected_team_games.get(item.team, 0.0),
+            )
+        )
+    return projections
+
+
+def project_goalie_teams(inputs: list[GoalieTeamProjectionInput], expected_team_games: dict[str, float]) -> list[GoalieTeamProjection]:
+    projections: list[GoalieTeamProjection] = []
+    for item in inputs:
+        per_game = rate_per_game(
+            goalie_team_points_raw(item.season_wins, item.season_goaltender_assists, item.season_shutouts),
+            82,
+        )
+        projections.append(
+            GoalieTeamProjection(team=item.team, expected_points=per_game * expected_team_games.get(item.team, 0.0))
+        )
+    return projections

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+from models import GoalieTeamProjection, SkaterProjection
+
+
+@dataclass(frozen=True)
+class LineupConstraints:
+    forwards: int = 5
+    defense: int = 3
+    goalie_teams: int = 2
+
+
+@dataclass(frozen=True)
+class OptimizedLineup:
+    forwards: list[SkaterProjection]
+    defense: list[SkaterProjection]
+    goalie_teams: list[GoalieTeamProjection]
+
+
+def optimize_lineup(
+    skaters: list[SkaterProjection],
+    goalie_teams: list[GoalieTeamProjection],
+    constraints: LineupConstraints,
+) -> OptimizedLineup:
+    forwards = sorted((x for x in skaters if x.position == "F"), key=lambda x: x.expected_points, reverse=True)[: constraints.forwards]
+    defense = sorted((x for x in skaters if x.position == "D"), key=lambda x: x.expected_points, reverse=True)[: constraints.defense]
+    selected_goalie_teams = sorted(goalie_teams, key=lambda x: x.expected_points, reverse=True)[: constraints.goalie_teams]
+    return OptimizedLineup(forwards=forwards, defense=defense, goalie_teams=selected_goalie_teams)

--- a/src/player.py
+++ b/src/player.py
@@ -8,6 +8,7 @@ class PlayerStats:
         self.goals = int(data.get("G", 0))
         self.assists = int(data.get("A", 0))
         self.points = int(data.get("P", 0))
+        self.overtime_goals = int(data.get("OTG", 0))
         self.pim = int(data.get("PIM", 0))
         self.plus_minus = int(data.get("+/-", 0))
         self.toi = data.get("TOI", "")

--- a/src/playoff_draft.py
+++ b/src/playoff_draft.py
@@ -1,107 +1,43 @@
-import csv
-import os
 from typing import Callable
 
-from player import Player
-from team import Team
 import heuristics
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-ROOT_DIR = os.path.dirname(SCRIPT_DIR)
-RESOURCES_DIR = os.path.join(ROOT_DIR, "resources", "2026")
-OUTPUT_DIR = os.path.join(ROOT_DIR, "out", "season_2026")
-
-
-# I/O
-def read_csv_to_dicts(filename) -> list[dict[str, str]]:
-    with open(os.path.join(RESOURCES_DIR, filename), mode="r", newline="", encoding="utf-8") as f:
-        csv_reader = csv.DictReader(f, delimiter="\t")
-        return list(csv_reader)
-
-
-def write_players_to_csv(players: list[Player], filename):
-    with open(os.path.join(OUTPUT_DIR, filename), "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f, delimiter="\t")
-        writer.writerow(["EV", "Name", "Team", "TEV", "Pos", "GP", "SGP", "G", "A", "P", "ESP", "PM", "S", "Bl", "H"])
-        for p in players:
-            writer.writerow([f"{p.estimatedValue:.3f}", p.name, p.team.name, f"{p.team.estimatedValue:.3f}", p.position,
-                             p.seasonStats.games_played, p.stretchStats.games_played, p.seasonStats.goals, 
-                             p.seasonStats.assists, p.seasonStats.points, p.seasonStats.even_strength_points,
-                             p.seasonStats.plus_minus, p.seasonStats.shots, p.seasonStats.blocks, p.seasonStats.hits])
-
-def write_teams_to_csv(teams: list[Team], filename):
-    with open(os.path.join(OUTPUT_DIR, filename), "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f, delimiter="\t")
-        writer.writerow(["EV", "Name"])
-        for team in teams:
-            writer.writerow([f"{team.estimatedValue:.3f}", team.name])
-
-def get_teams():
-    return [Team(v) for v in read_csv_to_dicts("teams.tsv")]
-    # return [Team.from_name(v) for v in [
-    #     "ANA", "BOS", "BUF", "CAR", "CBJ", "CGY", "CHI", "COL", "DAL", "DET", "EDM", "FLA", "LAK", "MIN",
-    #     "MTL", "NJD", "NSH", "NYI", "NYR", "OTT", "PHI", "PIT", "SEA", "SJS", "STL", "TBL", "TOR", "UTA",
-    #     "VAN", "VGK", "WPG", "WSH"
-    # ]]
-
-
-def get_players(teams: list[Team]) -> list[Player]:
-    player_season_stats = read_csv_to_dicts("players_season.tsv")
-    player_stretch_stats = read_csv_to_dicts("players_stretch.tsv")
-    player_prev_season_stats = read_csv_to_dicts("players_prev_season.tsv")
-
-    # TODO: optimize, but eh who cares. small data.
-    results = []
-    for season_stats in player_season_stats:
-        for stretch_stats in player_stretch_stats:
-            matching1 = season_stats["Name"] == stretch_stats["Name"] and season_stats["Team"] == stretch_stats["Team"]
-            for prev_season_stats in player_prev_season_stats:
-                matching2 = season_stats["Name"] == prev_season_stats["Name"] and season_stats["Team"] == prev_season_stats["Team"]
-                if matching1 and matching2:
-                    for team in teams:
-                        if team.name == season_stats["Team"]:
-                            results.append(Player(team, season_stats, stretch_stats, prev_season_stats))
-                            break
-                    break
-            else:
-                if matching1:
-                    for team in teams:
-                        if team.name == season_stats["Team"]:
-                            results.append(Player(team, season_stats, stretch_stats))
-                    break
-
-    return results
-
-
-def write_results(teams: list[Team], players: list[Player], output_dir: str):
-    os.makedirs(output_dir, exist_ok=True)
-
-    write_teams_to_csv(teams, os.path.join(output_dir, "teams.tsv"))
-
-    write_players_to_csv(players, os.path.join(output_dir, "all.tsv"))
-
-    forwards = filter(lambda x: x.position == "F", players)
-    write_players_to_csv(forwards, os.path.join(output_dir, "forwards.tsv"))
-
-    defense = filter(lambda x: x.position == "D", players)
-    write_players_to_csv(defense, os.path.join(output_dir, "defense.tsv"))
+from config import (
+    DEFAULT_EXPECTED_TEAM_GAMES,
+    OUTPUT_DIR,
+    PLAYER_PREV_SEASON_FILE,
+    PLAYER_SEASON_FILE,
+    PLAYER_STRETCH_FILE,
+    RESOURCES_DIR,
+    ROSTER,
+    TEAM_FILE,
+)
+from data_loader import DataLoader, ResourceFiles
+from models import project_goalie_teams, project_skaters
+from optimizer import LineupConstraints, optimize_lineup
+from player import Player
+from reporting import write_ranked_results
+from team import Team
 
 
 # HEURISTICS
-def normalize_team_values(teams, new_min=0.8, new_max=1.2):
+
+def normalize_team_values(teams: list[Team], new_min=0.8, new_max=1.2):
     if not teams:
         return
-    values = [t.estimatedValue for t in teams]
+
+    values = [team.estimatedValue for team in teams]
     min_val = min(values)
     max_val = max(values)
+
     if min_val == max_val:
         mid = (new_min + new_max) / 2
-        for t in teams:
-            t.estimatedValue = mid
+        for team in teams:
+            team.estimatedValue = mid
         return
+
     scale = (new_max - new_min) / (max_val - min_val)
-    for t in teams:
-        t.estimatedValue = new_min + (t.estimatedValue - min_val) * scale
+    for team in teams:
+        team.estimatedValue = new_min + (team.estimatedValue - min_val) * scale
 
 
 def set_team_estimated_values(teams: list[Team], players: list[Player], heuristic: Callable[[Team, list[Player]], float]):
@@ -109,26 +45,60 @@ def set_team_estimated_values(teams: list[Team], players: list[Player], heuristi
         team.estimatedValue = heuristic(team, players)
 
     normalize_team_values(teams)
-    teams.sort(key=lambda x: x.estimatedValue, reverse=True)
+    teams.sort(key=lambda item: item.estimatedValue, reverse=True)
 
 
 def set_player_estimated_values(players: list[Player], heuristic: Callable[[Player], float]):
     for player in players:
         player.estimatedValue = heuristic(player)
 
-    players.sort(key=lambda x: x.estimatedValue, reverse=True)
+    players.sort(key=lambda item: item.estimatedValue, reverse=True)
 
 
-# MAIN
+def _build_expected_games_map(teams: list[Team]) -> dict[str, float]:
+    return {team.name: team.estimatedValue * DEFAULT_EXPECTED_TEAM_GAMES for team in teams}
+
+
 def main():
-    teams = get_teams()
-    players = get_players(teams)
+    loader = DataLoader(
+        resources_dir=RESOURCES_DIR,
+        resource_files=ResourceFiles(
+            teams_file=TEAM_FILE,
+            player_season_file=PLAYER_SEASON_FILE,
+            player_stretch_file=PLAYER_STRETCH_FILE,
+            player_prev_season_file=PLAYER_PREV_SEASON_FILE,
+        ),
+        strict=False,
+    )
+
+    teams = loader.load_teams()
+    players = loader.load_players(teams)
 
     set_team_estimated_values(teams, players, heuristics.get_team_weight_diff_penalty)
     set_player_estimated_values(players, heuristics.sum_team_odds_multiply_points_stretch_weighted_per_game)
 
-    write_results(teams, players, OUTPUT_DIR)
+    expected_team_games = _build_expected_games_map(teams)
+    skater_inputs = loader.to_skater_projection_inputs(players)
+    goalie_team_inputs = loader.to_goalie_team_projection_inputs(teams)
+    skater_projections = project_skaters(skater_inputs, expected_team_games)
+    goalie_team_projections = project_goalie_teams(goalie_team_inputs, expected_team_games)
 
+    lineup = optimize_lineup(
+        skaters=skater_projections,
+        goalie_teams=goalie_team_projections,
+        constraints=LineupConstraints(
+            forwards=ROSTER.forwards,
+            defense=ROSTER.defense,
+            goalie_teams=ROSTER.goalie_teams,
+        ),
+    )
+
+    write_ranked_results(teams, players, OUTPUT_DIR)
+
+    print(loader.diagnostics_summary())
+    print(
+        f"optimized lineup sizes: F={len(lineup.forwards)}, D={len(lineup.defense)}, GT={len(lineup.goalie_teams)}"
+    )
     print("SUCCESS")
 
 

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -1,0 +1,49 @@
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from player import Player
+from team import Team
+
+PLAYER_HEADERS = ["EV", "Name", "Team", "TEV", "Pos", "GP", "SGP", "G", "A", "P", "ESP", "PM", "S", "Bl", "H"]
+TEAM_HEADERS = ["EV", "Name"]
+
+
+def write_players_to_tsv(players: Iterable[Player], output_path: Path) -> None:
+    with open(output_path, "w", newline="", encoding="utf-8") as file_handle:
+        writer = csv.writer(file_handle, delimiter="\t")
+        writer.writerow(PLAYER_HEADERS)
+        for player in players:
+            writer.writerow([
+                f"{player.estimatedValue:.3f}",
+                player.name,
+                player.team.name,
+                f"{player.team.estimatedValue:.3f}",
+                player.position,
+                player.seasonStats.games_played,
+                player.stretchStats.games_played,
+                player.seasonStats.goals,
+                player.seasonStats.assists,
+                player.seasonStats.points,
+                player.seasonStats.even_strength_points,
+                player.seasonStats.plus_minus,
+                player.seasonStats.shots,
+                player.seasonStats.blocks,
+                player.seasonStats.hits,
+            ])
+
+
+def write_teams_to_tsv(teams: list[Team], output_path: Path) -> None:
+    with open(output_path, "w", newline="", encoding="utf-8") as file_handle:
+        writer = csv.writer(file_handle, delimiter="\t")
+        writer.writerow(TEAM_HEADERS)
+        for team in teams:
+            writer.writerow([f"{team.estimatedValue:.3f}", team.name])
+
+
+def write_ranked_results(teams: list[Team], players: list[Player], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_teams_to_tsv(teams, output_dir / "teams.tsv")
+    write_players_to_tsv(players, output_dir / "all.tsv")
+    write_players_to_tsv((player for player in players if player.position == "F"), output_dir / "forwards.tsv")
+    write_players_to_tsv((player for player in players if player.position == "D"), output_dir / "defense.tsv")

--- a/src/scoring.py
+++ b/src/scoring.py
@@ -1,0 +1,25 @@
+
+def skater_points_raw(goals: int, assists: int, ot_goals: int) -> float:
+    return float(goals + assists + ot_goals)
+
+
+def skater_points_from_summary(points: int, ot_goals: int) -> float:
+    return float(points + ot_goals)
+
+
+def goalie_team_points_raw(wins: int, assists: int, shutouts: int) -> float:
+    return float(wins + assists + (5 * shutouts))
+
+
+def rate_per_game(total_points: float, games_played: int) -> float:
+    if games_played <= 0:
+        return 0.0
+    return float(total_points) / games_played
+
+
+def blend_rates(season_rate: float, stretch_rate: float, stretch_gp: int, k: int) -> float:
+    if stretch_gp <= 0:
+        return season_rate
+
+    weight = stretch_gp / (stretch_gp + k)
+    return (weight * stretch_rate) + ((1 - weight) * season_rate)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from config import ROSTER, SCORING
+
+
+class ConfigDefaultsTests(unittest.TestCase):
+    def test_scoring_defaults(self):
+        self.assertEqual(SCORING.skater_goal, 1)
+        self.assertEqual(SCORING.skater_assist, 1)
+        self.assertEqual(SCORING.skater_ot_goal_bonus, 1)
+        self.assertEqual(SCORING.goalie_win, 1)
+        self.assertEqual(SCORING.goalie_assist, 1)
+        self.assertEqual(SCORING.goalie_shutout, 5)
+
+    def test_roster_defaults(self):
+        self.assertEqual(ROSTER.forwards, 5)
+        self.assertEqual(ROSTER.defense, 3)
+        self.assertEqual(ROSTER.goalie_teams, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,50 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from data_loader import DataLoader, ResourceFiles
+from team import Team
+
+
+class DataLoaderTests(unittest.TestCase):
+    def test_missing_required_column_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resources = Path(tmpdir)
+            (resources / "teams.tsv").write_text("Name\tRound1\tRound2\tConference\nA\t0.5\t0.2\t0.1\n", encoding="utf-8")
+            (resources / "players_season.tsv").write_text("Name\tTeam\tPos\tGP\tP\nA\tAAA\tF\t1\t1\n", encoding="utf-8")
+            (resources / "players_stretch.tsv").write_text("Name\tTeam\tPos\tGP\tP\nA\tAAA\tF\t1\t1\n", encoding="utf-8")
+            (resources / "players_prev_season.tsv").write_text("Name\tTeam\tPos\tGP\tP\nA\tAAA\tF\t1\t1\n", encoding="utf-8")
+
+            loader = DataLoader(
+                resources,
+                ResourceFiles("teams.tsv", "players_season.tsv", "players_stretch.tsv", "players_prev_season.tsv"),
+            )
+
+            with self.assertRaises(ValueError):
+                loader.load_teams()
+
+    def test_strict_mode_raises_on_dropped_players(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resources = Path(tmpdir)
+            (resources / "teams.tsv").write_text(
+                "Name\tRound1\tRound2\tConference\tFinal\nAAA\t0.5\t0.2\t0.1\t0.05\n", encoding="utf-8"
+            )
+            (resources / "players_season.tsv").write_text("Name\tTeam\tPos\tGP\tP\nA\tAAA\tF\t1\t1\n", encoding="utf-8")
+            (resources / "players_stretch.tsv").write_text("Name\tTeam\tPos\tGP\tP\n", encoding="utf-8")
+            (resources / "players_prev_season.tsv").write_text("Name\tTeam\tPos\tGP\tP\nA\tAAA\tF\t1\t1\n", encoding="utf-8")
+
+            loader = DataLoader(
+                resources,
+                ResourceFiles("teams.tsv", "players_season.tsv", "players_stretch.tsv", "players_prev_season.tsv"),
+                strict=True,
+            )
+            teams = [Team({"Name": "AAA", "Round1": "0.5", "Round2": "0.2", "Conference": "0.1", "Final": "0.05"})]
+            with self.assertRaises(ValueError):
+                loader.load_players(teams)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a modular, testable foundation for heuristic, scoring, projection and optimization work so future improvements can be made without repeatedly editing I/O glue code.  
- Replace ad-hoc TSV handling and inlined logic with typed contracts, explicit scoring formulas, and clearer data diagnostics.  
- Prepare for an expected-games model and stronger optimizer by standardizing inputs/outputs and adding a roadmap to implementable heuristics.  

### Description
- Introduces module boundaries and configuration: adds `src/config.py`, `src/contracts.py`, `src/scoring.py`, `src/models.py`, `src/optimizer.py`, `src/data_loader.py`, and `src/reporting.py`, and refactors `src/playoff_draft.py` to orchestrate via these modules.  
- Implements TSV-based ingestion with validation and diagnostics in `DataLoader`, keyed joins by `(Name, Team)`, strict-mode behavior, and conversion helpers to typed projection inputs.  
- Adds pure scoring helpers (`skater_points_*`, `goalie_team_points_raw`, `rate_per_game`, `blend_rates`) and projection logic in `project_skaters` and `project_goalie_teams` that blend season/stretch rates and apply expected team games.  
- Adds a deterministic greedy lineup optimizer selecting top-N by position and reporting helpers that write ranked TSVs to `out/season_2026`, plus an expanded `README.md` and a detailed `docs/heuristics_implementation_plan.md`.  
- Small model/field updates: `PlayerStats` now reads `OTG` into `overtime_goals`, normalization and sort callsites were tightened, and a helper `_build_expected_games_map` was added to bridge team EVs to expected games via `DEFAULT_EXPECTED_TEAM_GAMES`.  

### Testing
- Added unit tests `tests/test_config.py` and `tests/test_data_loader.py` and ran them with `python -m unittest discover -s tests -p 'test_*.py'`.  
- Both tests completed successfully (config defaults and data loader validation/strict-mode behavior passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18d4a196c832996fc0e81d4ce7645)