### PR TITLE
Add 4.x optimizer: risk-aware scoring, team exposure constraints, and API update

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -24,12 +24,14 @@ class SkaterProjection:
     team: str
     position: str
     expected_points: float
+    expected_points_std: float = 0.0
 
 
 @dataclass(frozen=True)
 class GoalieTeamProjection:
     team: str
     expected_points: float
+    expected_points_std: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable
 
 from models import GoalieTeamProjection, SkaterProjection
 
@@ -8,6 +10,8 @@ class LineupConstraints:
     forwards: int = 5
     defense: int = 3
     goalie_teams: int = 2
+    max_skaters_per_team: int | None = None
+    max_total_from_team_including_goalie_team: int | None = None
 
 
 @dataclass(frozen=True)
@@ -15,14 +19,157 @@ class OptimizedLineup:
     forwards: list[SkaterProjection]
     defense: list[SkaterProjection]
     goalie_teams: list[GoalieTeamProjection]
+    objective_value: float
+
+
+def _stable_skater_key(skater: SkaterProjection) -> tuple[str, str, str]:
+    return (skater.team, skater.position, skater.name)
+
+
+def _stable_goalie_team_key(goalie_team: GoalieTeamProjection) -> tuple[str]:
+    return (goalie_team.team,)
+
+
+def _score_skater(skater: SkaterProjection, risk_lambda: float) -> float:
+    return skater.expected_points - (risk_lambda * skater.expected_points_std)
+
+
+def _score_goalie_team(goalie_team: GoalieTeamProjection, risk_lambda: float) -> float:
+    return goalie_team.expected_points - (risk_lambda * goalie_team.expected_points_std)
+
+
+def _objective(
+    selected_forwards: Iterable[SkaterProjection],
+    selected_defense: Iterable[SkaterProjection],
+    selected_goalie_teams: Iterable[GoalieTeamProjection],
+    risk_lambda: float,
+) -> float:
+    total = sum(_score_skater(x, risk_lambda) for x in selected_forwards)
+    total += sum(_score_skater(x, risk_lambda) for x in selected_defense)
+    total += sum(_score_goalie_team(x, risk_lambda) for x in selected_goalie_teams)
+    return total
+
+
+def _respects_optional_team_constraints(
+    selected_forwards: tuple[SkaterProjection, ...],
+    selected_defense: tuple[SkaterProjection, ...],
+    selected_goalie_teams: tuple[GoalieTeamProjection, ...],
+    constraints: LineupConstraints,
+) -> bool:
+    if constraints.max_skaters_per_team is not None:
+        skaters_per_team: dict[str, int] = {}
+        for skater in (*selected_forwards, *selected_defense):
+            skaters_per_team[skater.team] = skaters_per_team.get(skater.team, 0) + 1
+        if any(count > constraints.max_skaters_per_team for count in skaters_per_team.values()):
+            return False
+
+    if constraints.max_total_from_team_including_goalie_team is not None:
+        total_per_team: dict[str, int] = {}
+        for skater in (*selected_forwards, *selected_defense):
+            total_per_team[skater.team] = total_per_team.get(skater.team, 0) + 1
+        for goalie_team in selected_goalie_teams:
+            total_per_team[goalie_team.team] = total_per_team.get(goalie_team.team, 0) + 1
+        if any(count > constraints.max_total_from_team_including_goalie_team for count in total_per_team.values()):
+            return False
+
+    return True
+
+
+def _validate_pool_sizes(
+    forwards: list[SkaterProjection],
+    defense: list[SkaterProjection],
+    goalie_teams: list[GoalieTeamProjection],
+    constraints: LineupConstraints,
+) -> None:
+    if len(forwards) < constraints.forwards:
+        raise ValueError(f"Not enough forwards to satisfy roster constraint: need {constraints.forwards}, got {len(forwards)}")
+    if len(defense) < constraints.defense:
+        raise ValueError(f"Not enough defense to satisfy roster constraint: need {constraints.defense}, got {len(defense)}")
+    if len(goalie_teams) < constraints.goalie_teams:
+        raise ValueError(
+            f"Not enough goalie teams to satisfy roster constraint: need {constraints.goalie_teams}, got {len(goalie_teams)}"
+        )
+
+
+def _optimize_without_cross_pool_constraints(
+    forwards: list[SkaterProjection],
+    defense: list[SkaterProjection],
+    goalie_teams: list[GoalieTeamProjection],
+    constraints: LineupConstraints,
+    risk_lambda: float,
+) -> OptimizedLineup:
+    selected_forwards = sorted(forwards, key=lambda x: (-_score_skater(x, risk_lambda), _stable_skater_key(x)))[: constraints.forwards]
+    selected_defense = sorted(defense, key=lambda x: (-_score_skater(x, risk_lambda), _stable_skater_key(x)))[: constraints.defense]
+    selected_goalie_teams = sorted(
+        goalie_teams, key=lambda x: (-_score_goalie_team(x, risk_lambda), _stable_goalie_team_key(x))
+    )[: constraints.goalie_teams]
+
+    return OptimizedLineup(
+        forwards=selected_forwards,
+        defense=selected_defense,
+        goalie_teams=selected_goalie_teams,
+        objective_value=_objective(selected_forwards, selected_defense, selected_goalie_teams, risk_lambda),
+    )
+
+
+def _optimize_with_optional_constraints(
+    forwards: list[SkaterProjection],
+    defense: list[SkaterProjection],
+    goalie_teams: list[GoalieTeamProjection],
+    constraints: LineupConstraints,
+    risk_lambda: float,
+) -> OptimizedLineup:
+    sorted_forwards = sorted(forwards, key=lambda x: (-_score_skater(x, risk_lambda), _stable_skater_key(x)))
+    sorted_defense = sorted(defense, key=lambda x: (-_score_skater(x, risk_lambda), _stable_skater_key(x)))
+    sorted_goalie_teams = sorted(
+        goalie_teams, key=lambda x: (-_score_goalie_team(x, risk_lambda), _stable_goalie_team_key(x))
+    )
+
+    best: tuple[float, tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]], OptimizedLineup] | None = None
+    for forward_selection in combinations(sorted_forwards, constraints.forwards):
+        for defense_selection in combinations(sorted_defense, constraints.defense):
+            for goalie_selection in combinations(sorted_goalie_teams, constraints.goalie_teams):
+                if not _respects_optional_team_constraints(
+                    selected_forwards=forward_selection,
+                    selected_defense=defense_selection,
+                    selected_goalie_teams=goalie_selection,
+                    constraints=constraints,
+                ):
+                    continue
+
+                objective_value = _objective(forward_selection, defense_selection, goalie_selection, risk_lambda)
+                tiebreak_key = (
+                    tuple(x.name for x in forward_selection),
+                    tuple(x.name for x in defense_selection),
+                    tuple(x.team for x in goalie_selection),
+                )
+                lineup = OptimizedLineup(
+                    forwards=list(forward_selection),
+                    defense=list(defense_selection),
+                    goalie_teams=list(goalie_selection),
+                    objective_value=objective_value,
+                )
+                if best is None or objective_value > best[0] or (objective_value == best[0] and tiebreak_key < best[1]):
+                    best = (objective_value, tiebreak_key, lineup)
+
+    if best is None:
+        raise ValueError("No feasible lineup satisfies the provided constraints")
+    return best[2]
 
 
 def optimize_lineup(
-    skaters: list[SkaterProjection],
+    forwards: list[SkaterProjection],
+    defense: list[SkaterProjection],
     goalie_teams: list[GoalieTeamProjection],
     constraints: LineupConstraints,
+    risk_lambda: float = 0.0,
 ) -> OptimizedLineup:
-    forwards = sorted((x for x in skaters if x.position == "F"), key=lambda x: x.expected_points, reverse=True)[: constraints.forwards]
-    defense = sorted((x for x in skaters if x.position == "D"), key=lambda x: x.expected_points, reverse=True)[: constraints.defense]
-    selected_goalie_teams = sorted(goalie_teams, key=lambda x: x.expected_points, reverse=True)[: constraints.goalie_teams]
-    return OptimizedLineup(forwards=forwards, defense=defense, goalie_teams=selected_goalie_teams)
+    _validate_pool_sizes(forwards, defense, goalie_teams, constraints)
+
+    has_optional_team_constraints = (
+        constraints.max_skaters_per_team is not None or constraints.max_total_from_team_including_goalie_team is not None
+    )
+    if not has_optional_team_constraints:
+        return _optimize_without_cross_pool_constraints(forwards, defense, goalie_teams, constraints, risk_lambda)
+
+    return _optimize_with_optional_constraints(forwards, defense, goalie_teams, constraints, risk_lambda)

--- a/src/playoff_draft.py
+++ b/src/playoff_draft.py
@@ -81,7 +81,8 @@ def main():
     goalie_team_projections = project_goalie_teams(goalie_team_inputs, expected_team_games)
 
     lineup = optimize_lineup(
-        skaters=skater_projections,
+        forwards=[x for x in skater_projections if x.position == "F"],
+        defense=[x for x in skater_projections if x.position == "D"],
         goalie_teams=goalie_team_projections,
         constraints=LineupConstraints(
             forwards=ROSTER.forwards,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,101 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from models import GoalieTeamProjection, SkaterProjection
+from optimizer import LineupConstraints, optimize_lineup
+
+
+class OptimizerTests(unittest.TestCase):
+    def test_exact_constraints_are_satisfied(self):
+        forwards = [
+            SkaterProjection(name="F1", team="AAA", position="F", expected_points=5.0),
+            SkaterProjection(name="F2", team="AAA", position="F", expected_points=4.0),
+            SkaterProjection(name="F3", team="BBB", position="F", expected_points=6.0),
+            SkaterProjection(name="F4", team="BBB", position="F", expected_points=3.0),
+            SkaterProjection(name="F5", team="CCC", position="F", expected_points=2.0),
+            SkaterProjection(name="F6", team="DDD", position="F", expected_points=1.0),
+        ]
+        defense = [
+            SkaterProjection(name="D1", team="AAA", position="D", expected_points=4.5),
+            SkaterProjection(name="D2", team="BBB", position="D", expected_points=3.5),
+            SkaterProjection(name="D3", team="CCC", position="D", expected_points=2.5),
+            SkaterProjection(name="D4", team="DDD", position="D", expected_points=1.5),
+        ]
+        goalie_teams = [
+            GoalieTeamProjection(team="AAA", expected_points=7.0),
+            GoalieTeamProjection(team="BBB", expected_points=6.0),
+            GoalieTeamProjection(team="CCC", expected_points=5.0),
+        ]
+
+        lineup = optimize_lineup(
+            forwards=forwards,
+            defense=defense,
+            goalie_teams=goalie_teams,
+            constraints=LineupConstraints(forwards=5, defense=3, goalie_teams=2),
+        )
+
+        self.assertEqual(len(lineup.forwards), 5)
+        self.assertEqual(len(lineup.defense), 3)
+        self.assertEqual(len(lineup.goalie_teams), 2)
+
+    def test_tie_breaking_is_deterministic(self):
+        forwards = [
+            SkaterProjection(name="FA", team="AAA", position="F", expected_points=10.0),
+            SkaterProjection(name="FB", team="AAA", position="F", expected_points=10.0),
+        ]
+        defense = [SkaterProjection(name="DA", team="AAA", position="D", expected_points=5.0)]
+        goalie_teams = [GoalieTeamProjection(team="AAA", expected_points=3.0)]
+
+        lineup = optimize_lineup(
+            forwards=forwards,
+            defense=defense,
+            goalie_teams=goalie_teams,
+            constraints=LineupConstraints(forwards=1, defense=1, goalie_teams=1),
+        )
+
+        self.assertEqual(lineup.forwards[0].name, "FA")
+
+    def test_optional_team_constraints_are_enforced(self):
+        forwards = [
+            SkaterProjection(name="F1", team="AAA", position="F", expected_points=12.0),
+            SkaterProjection(name="F2", team="AAA", position="F", expected_points=11.0),
+            SkaterProjection(name="F3", team="BBB", position="F", expected_points=7.0),
+        ]
+        defense = [
+            SkaterProjection(name="D1", team="AAA", position="D", expected_points=9.0),
+            SkaterProjection(name="D2", team="BBB", position="D", expected_points=8.0),
+        ]
+        goalie_teams = [
+            GoalieTeamProjection(team="AAA", expected_points=10.0),
+            GoalieTeamProjection(team="BBB", expected_points=6.0),
+        ]
+
+        lineup = optimize_lineup(
+            forwards=forwards,
+            defense=defense,
+            goalie_teams=goalie_teams,
+            constraints=LineupConstraints(
+                forwards=2,
+                defense=1,
+                goalie_teams=1,
+                max_skaters_per_team=2,
+                max_total_from_team_including_goalie_team=2,
+            ),
+        )
+
+        team_counts: dict[str, int] = {}
+        for skater in [*lineup.forwards, *lineup.defense]:
+            team_counts[skater.team] = team_counts.get(skater.team, 0) + 1
+        self.assertLessEqual(max(team_counts.values()), 2)
+
+        total_team_counts = dict(team_counts)
+        for goalie_team in lineup.goalie_teams:
+            total_team_counts[goalie_team.team] = total_team_counts.get(goalie_team.team, 0) + 1
+        self.assertLessEqual(max(total_team_counts.values()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Prepare the optimizer for the 4.x doc implementation plan by introducing risk-aware scoring and explicit team-exposure limits.
- Make the optimizer API more explicit by accepting separate forward/defense pools to simplify downstream integration and deterministic selection.
- Provide deterministic tie-breaking and pool validation so lineups are reproducible and invalid inputs fail fast.

### Description

- Add an optional `expected_points_std` field to `SkaterProjection` and `GoalieTeamProjection` so risk-adjusted scoring can be computed without breaking existing callers (`src/models.py`).
- Refactor `optimize_lineup` to accept explicit `forwards` and `defense` pools, return an `objective_value`, and accept a `risk_lambda` parameter for risk-aware scoring (`src/optimizer.py`).
- Implement optional exposure constraints `max_skaters_per_team` and `max_total_from_team_including_goalie_team`, deterministic tie-breaking, pool-size validation, and two optimization paths (fast greedy when no cross-pool constraints, exhaustive/search with tiebreaking when constraints present) (`src/optimizer.py`).
- Update integration in `playoff_draft.py` to pass separated forward/defense pools to the new optimizer signature, and add unit tests in `tests/test_optimizer.py` covering roster sizing, deterministic tie-breaking, and optional team-constraint enforcement.

### Testing

- Ran the optimizer unit tests with `python -m unittest -v tests/test_optimizer.py` and all tests passed (3 tests OK).
- No additional automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19cfe67b08329b37cd42f2fa751fa)