### PR TITLE
Implement 5.x data reliability diagnostics pipeline

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -22,14 +22,43 @@ class LoadDiagnostics:
     prev_rows: int = 0
     team_rows: int = 0
     players_loaded: int = 0
+    teams_loaded: int = 0
     skipped_missing_stretch: int = 0
     skipped_missing_team: int = 0
+    dropped_invalid_numeric: int = 0
+    dropped_by_reason: dict[str, int] = field(default_factory=dict)
+    critical_missing_counts: dict[str, int] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
+
+    def bump_drop_reason(self, reason: str) -> None:
+        self.dropped_by_reason[reason] = self.dropped_by_reason.get(reason, 0) + 1
+
+
+@dataclass(frozen=True)
+class ParseContext:
+    file: str
+    row: int
+    column: str
+
+
+@dataclass(frozen=True)
+class ParseIssue:
+    context: ParseContext
+    reason: str
+    value: str
+
+    def as_warning(self) -> str:
+        return (
+            f"{self.reason}: file={self.context.file}, row={self.context.row}, "
+            f"column={self.context.column}, value={self.value!r}"
+        )
 
 
 class DataLoader:
     REQUIRED_TEAM_COLUMNS = {"Name", "Round1", "Round2", "Conference", "Final"}
     REQUIRED_PLAYER_COLUMNS = {"Name", "Team", "Pos", "GP", "P"}
+    CRITICAL_PLAYER_FIELDS = ("GP", "P", "OTG")
+    CRITICAL_TEAM_FIELDS = ("Round1", "Round2", "Conference", "Final")
 
     def __init__(self, resources_dir: Path, resource_files: ResourceFiles, strict: bool = False):
         self.resources_dir = Path(resources_dir)
@@ -41,7 +70,28 @@ class DataLoader:
         teams_data = self._read_tsv(self.resource_files.teams_file)
         self.diagnostics.team_rows = len(teams_data)
         self._validate_columns(self.resource_files.teams_file, teams_data, self.REQUIRED_TEAM_COLUMNS)
-        return [Team(row) for row in teams_data]
+        self._track_missing_counts(
+            filename=self.resource_files.teams_file,
+            rows=teams_data,
+            critical_fields=self.CRITICAL_TEAM_FIELDS,
+        )
+
+        teams: list[Team] = []
+        for row_idx, row in enumerate(teams_data, start=2):
+            issue = self._validate_numeric_fields(
+                filename=self.resource_files.teams_file,
+                row=row,
+                row_idx=row_idx,
+                fields=self.CRITICAL_TEAM_FIELDS,
+            )
+            if issue is not None:
+                self._drop_row("invalid_team_numeric", issue)
+                continue
+
+            teams.append(Team(row))
+
+        self.diagnostics.teams_loaded = len(teams)
+        return teams
 
     def load_players(self, teams: list[Team]) -> list[Player]:
         season_rows = self._read_tsv(self.resource_files.player_season_file)
@@ -54,24 +104,72 @@ class DataLoader:
 
         self._validate_columns(self.resource_files.player_season_file, season_rows, self.REQUIRED_PLAYER_COLUMNS)
         self._validate_columns(self.resource_files.player_stretch_file, stretch_rows, self.REQUIRED_PLAYER_COLUMNS)
+        self._track_missing_counts(
+            filename=self.resource_files.player_season_file,
+            rows=season_rows,
+            critical_fields=self.CRITICAL_PLAYER_FIELDS,
+        )
+        self._track_missing_counts(
+            filename=self.resource_files.player_stretch_file,
+            rows=stretch_rows,
+            critical_fields=self.CRITICAL_PLAYER_FIELDS,
+        )
+        self._track_missing_counts(
+            filename=self.resource_files.player_prev_season_file,
+            rows=prev_rows,
+            critical_fields=self.CRITICAL_PLAYER_FIELDS,
+        )
 
         teams_by_name = {team.name: team for team in teams}
         stretch_by_key = self._index_by_player_key(stretch_rows)
         prev_by_key = self._index_by_player_key(prev_rows)
 
         players: list[Player] = []
-        for season in season_rows:
+        for row_idx, season in enumerate(season_rows, start=2):
             key = self._player_key(season)
             stretch = stretch_by_key.get(key)
             team = teams_by_name.get(season.get("Team", ""))
             if stretch is None:
                 self.diagnostics.skipped_missing_stretch += 1
+                self.diagnostics.bump_drop_reason("no_stretch_match")
                 continue
             if team is None:
                 self.diagnostics.skipped_missing_team += 1
+                self.diagnostics.bump_drop_reason("no_team_match")
                 continue
 
             prev = prev_by_key.get(key, {})
+            season_issue = self._validate_numeric_fields(
+                filename=self.resource_files.player_season_file,
+                row=season,
+                row_idx=row_idx,
+                fields=self.CRITICAL_PLAYER_FIELDS,
+            )
+            if season_issue is not None:
+                self._drop_row("invalid_season_numeric", season_issue)
+                continue
+
+            stretch_issue = self._validate_numeric_fields(
+                filename=self.resource_files.player_stretch_file,
+                row=stretch,
+                row_idx=self._row_index(stretch_rows, stretch),
+                fields=self.CRITICAL_PLAYER_FIELDS,
+            )
+            if stretch_issue is not None:
+                self._drop_row("invalid_stretch_numeric", stretch_issue)
+                continue
+
+            if prev and (
+                prev_issue := self._validate_numeric_fields(
+                    filename=self.resource_files.player_prev_season_file,
+                    row=prev,
+                    row_idx=self._row_index(prev_rows, prev),
+                    fields=self.CRITICAL_PLAYER_FIELDS,
+                )
+            ):
+                self._drop_row("invalid_prev_numeric", prev_issue)
+                continue
+
             players.append(Player(team, season, stretch, prev))
 
         self.diagnostics.players_loaded = len(players)
@@ -147,6 +245,50 @@ class DataLoader:
     def _index_by_player_key(self, rows: list[dict[str, str]]) -> dict[tuple[str, str], dict[str, str]]:
         return {self._player_key(row): row for row in rows}
 
+    def _row_index(self, rows: list[dict[str, str]], match_row: dict[str, str]) -> int:
+        for idx, row in enumerate(rows, start=2):
+            if row is match_row:
+                return idx
+        return 0
+
+    def _drop_row(self, reason: str, issue: ParseIssue) -> None:
+        self.diagnostics.dropped_invalid_numeric += 1
+        self.diagnostics.bump_drop_reason(reason)
+        self.diagnostics.warnings.append(issue.as_warning())
+
+    def _track_missing_counts(self, filename: str, rows: list[dict[str, str]], critical_fields: tuple[str, ...]) -> None:
+        for column in critical_fields:
+            key = f"{filename}:{column}"
+            self.diagnostics.critical_missing_counts[key] = 0
+
+        for row in rows:
+            for column in critical_fields:
+                value = row.get(column, "")
+                if value is None or value.strip() == "":
+                    key = f"{filename}:{column}"
+                    self.diagnostics.critical_missing_counts[key] += 1
+
+    @staticmethod
+    def _validate_numeric_fields(
+        filename: str,
+        row: dict[str, str],
+        row_idx: int,
+        fields: tuple[str, ...],
+    ) -> ParseIssue | None:
+        for column in fields:
+            raw_value = row.get(column, "")
+            if raw_value is None or raw_value.strip() == "":
+                continue
+            try:
+                float(raw_value)
+            except ValueError:
+                return ParseIssue(
+                    context=ParseContext(file=filename, row=row_idx, column=column),
+                    reason="invalid numeric",
+                    value=raw_value,
+                )
+        return None
+
     def _finalize_diagnostics(self) -> None:
         if self.diagnostics.skipped_missing_stretch:
             self.diagnostics.warnings.append(
@@ -156,18 +298,28 @@ class DataLoader:
             self.diagnostics.warnings.append(
                 f"Skipped {self.diagnostics.skipped_missing_team} players with no known team"
             )
+        if self.diagnostics.dropped_invalid_numeric:
+            self.diagnostics.warnings.append(
+                f"Skipped {self.diagnostics.dropped_invalid_numeric} rows with invalid numeric values"
+            )
 
-        if self.strict and (self.diagnostics.skipped_missing_stretch or self.diagnostics.skipped_missing_team):
-            joined = "; ".join(self.diagnostics.warnings)
+        total_dropped = (
+            self.diagnostics.skipped_missing_stretch
+            + self.diagnostics.skipped_missing_team
+            + self.diagnostics.dropped_invalid_numeric
+        )
+        if self.strict and total_dropped:
+            joined = "; ".join(self.diagnostics.dropped_by_reason.keys())
             raise ValueError(f"Strict mode enabled, dropped players during load: {joined}")
 
     def diagnostics_summary(self) -> str:
         summary = (
-            f"loaded players={self.diagnostics.players_loaded} "
+            f"loaded teams={self.diagnostics.teams_loaded}, players={self.diagnostics.players_loaded} "
             f"from season={self.diagnostics.season_rows}, "
             f"stretch={self.diagnostics.stretch_rows}, "
             f"prev={self.diagnostics.prev_rows}; "
             f"skipped_missing_stretch={self.diagnostics.skipped_missing_stretch}, "
-            f"skipped_missing_team={self.diagnostics.skipped_missing_team}"
+            f"skipped_missing_team={self.diagnostics.skipped_missing_team}, "
+            f"dropped_invalid_numeric={self.diagnostics.dropped_invalid_numeric}"
         )
         return summary

--- a/src/playoff_draft.py
+++ b/src/playoff_draft.py
@@ -1,3 +1,4 @@
+import argparse
 from typing import Callable
 
 import heuristics
@@ -15,7 +16,7 @@ from data_loader import DataLoader, ResourceFiles
 from models import estimate_expected_games, project_goalie_teams, project_skaters
 from optimizer import LineupConstraints, optimize_lineup
 from player import Player
-from reporting import write_ranked_results
+from reporting import write_diagnostics, write_ranked_results
 from team import Team
 
 
@@ -55,7 +56,18 @@ def set_player_estimated_values(players: list[Player], heuristic: Callable[[Play
     players.sort(key=lambda item: item.estimatedValue, reverse=True)
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate playoff draft rankings and optimized lineup.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if any player/team rows are dropped during ingest or parsing.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
     loader = DataLoader(
         resources_dir=RESOURCES_DIR,
         resource_files=ResourceFiles(
@@ -64,7 +76,7 @@ def main():
             player_stretch_file=PLAYER_STRETCH_FILE,
             player_prev_season_file=PLAYER_PREV_SEASON_FILE,
         ),
-        strict=False,
+        strict=args.strict,
     )
 
     teams = loader.load_teams()
@@ -92,6 +104,7 @@ def main():
     )
 
     write_ranked_results(teams, players, OUTPUT_DIR)
+    write_diagnostics(loader.diagnostics, OUTPUT_DIR)
 
     print(loader.diagnostics_summary())
     print(

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -2,6 +2,7 @@ import csv
 from pathlib import Path
 from typing import Iterable
 
+from data_loader import LoadDiagnostics
 from player import Player
 from team import Team
 
@@ -47,3 +48,26 @@ def write_ranked_results(teams: list[Team], players: list[Player], output_dir: P
     write_players_to_tsv(players, output_dir / "all.tsv")
     write_players_to_tsv((player for player in players if player.position == "F"), output_dir / "forwards.tsv")
     write_players_to_tsv((player for player in players if player.position == "D"), output_dir / "defense.tsv")
+
+
+def write_diagnostics(diagnostics: LoadDiagnostics, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "diagnostics.tsv"
+    with open(output_path, "w", newline="", encoding="utf-8") as file_handle:
+        writer = csv.writer(file_handle, delimiter="\t")
+        writer.writerow(["metric", "value"])
+        writer.writerow(["season_rows", diagnostics.season_rows])
+        writer.writerow(["stretch_rows", diagnostics.stretch_rows])
+        writer.writerow(["prev_rows", diagnostics.prev_rows])
+        writer.writerow(["team_rows", diagnostics.team_rows])
+        writer.writerow(["teams_loaded", diagnostics.teams_loaded])
+        writer.writerow(["players_loaded", diagnostics.players_loaded])
+        writer.writerow(["skipped_missing_stretch", diagnostics.skipped_missing_stretch])
+        writer.writerow(["skipped_missing_team", diagnostics.skipped_missing_team])
+        writer.writerow(["dropped_invalid_numeric", diagnostics.dropped_invalid_numeric])
+
+        for reason, count in sorted(diagnostics.dropped_by_reason.items()):
+            writer.writerow([f"dropped_reason:{reason}", count])
+
+        for field_key, count in sorted(diagnostics.critical_missing_counts.items()):
+            writer.writerow([f"missing_critical:{field_key}", count])

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -45,6 +45,58 @@ class DataLoaderTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 loader.load_players(teams)
 
+    def test_non_strict_mode_skips_invalid_numeric_with_reason(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resources = Path(tmpdir)
+            (resources / "teams.tsv").write_text(
+                "Name\tRound1\tRound2\tConference\tFinal\nAAA\t0.5\t0.2\t0.1\t0.05\n", encoding="utf-8"
+            )
+            (resources / "players_season.tsv").write_text(
+                "Name\tTeam\tPos\tGP\tP\tOTG\nA\tAAA\tF\tbad\t1\t0\n", encoding="utf-8"
+            )
+            (resources / "players_stretch.tsv").write_text(
+                "Name\tTeam\tPos\tGP\tP\tOTG\nA\tAAA\tF\t1\t1\t0\n", encoding="utf-8"
+            )
+            (resources / "players_prev_season.tsv").write_text(
+                "Name\tTeam\tPos\tGP\tP\tOTG\nA\tAAA\tF\t1\t1\t0\n", encoding="utf-8"
+            )
+
+            loader = DataLoader(
+                resources,
+                ResourceFiles("teams.tsv", "players_season.tsv", "players_stretch.tsv", "players_prev_season.tsv"),
+                strict=False,
+            )
+            teams = loader.load_teams()
+            players = loader.load_players(teams)
+            self.assertEqual(players, [])
+            self.assertEqual(loader.diagnostics.dropped_invalid_numeric, 1)
+            self.assertEqual(loader.diagnostics.dropped_by_reason["invalid_season_numeric"], 1)
+
+    def test_strict_mode_raises_on_invalid_numeric(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resources = Path(tmpdir)
+            (resources / "teams.tsv").write_text(
+                "Name\tRound1\tRound2\tConference\tFinal\nAAA\t0.5\t0.2\t0.1\t0.05\n", encoding="utf-8"
+            )
+            (resources / "players_season.tsv").write_text(
+                "Name\tTeam\tPos\tGP\tP\tOTG\nA\tAAA\tF\tbad\t1\t0\n", encoding="utf-8"
+            )
+            (resources / "players_stretch.tsv").write_text(
+                "Name\tTeam\tPos\tGP\tP\tOTG\nA\tAAA\tF\t1\t1\t0\n", encoding="utf-8"
+            )
+            (resources / "players_prev_season.tsv").write_text(
+                "Name\tTeam\tPos\tGP\tP\tOTG\nA\tAAA\tF\t1\t1\t0\n", encoding="utf-8"
+            )
+
+            loader = DataLoader(
+                resources,
+                ResourceFiles("teams.tsv", "players_season.tsv", "players_stretch.tsv", "players_prev_season.tsv"),
+                strict=True,
+            )
+            teams = loader.load_teams()
+            with self.assertRaises(ValueError):
+                loader.load_players(teams)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,42 @@
+import csv
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from data_loader import LoadDiagnostics
+from reporting import write_diagnostics
+
+
+class ReportingTests(unittest.TestCase):
+    def test_write_diagnostics_includes_counts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            diagnostics = LoadDiagnostics(
+                season_rows=10,
+                stretch_rows=9,
+                prev_rows=8,
+                team_rows=16,
+                teams_loaded=15,
+                players_loaded=100,
+                skipped_missing_stretch=2,
+                skipped_missing_team=1,
+                dropped_invalid_numeric=3,
+                dropped_by_reason={"invalid_season_numeric": 3},
+                critical_missing_counts={"players_season.tsv:OTG": 5},
+            )
+            write_diagnostics(diagnostics, output_dir)
+
+            with open(output_dir / "diagnostics.tsv", newline="", encoding="utf-8") as file_handle:
+                rows = list(csv.reader(file_handle, delimiter="\t"))
+
+            self.assertEqual(rows[0], ["metric", "value"])
+            self.assertIn(["players_loaded", "100"], rows)
+            self.assertIn(["dropped_reason:invalid_season_numeric", "3"], rows)
+            self.assertIn(["missing_critical:players_season.tsv:OTG", "5"], rows)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Harden the ingest pipeline to meet the 5.x plan requirement for data reliability and make data issues visible for debugging and QA. 
- Provide contextual parse warnings (`file`, `row`, `column`) and per-file critical-field missing counts so dropped rows are auditable. 
- Add a `--strict` mode to fail fast when any rows are dropped, enabling safer CI/validation runs.

### Description
- Enhanced `DataLoader` with contextual parse structures (`ParseContext`, `ParseIssue`), numeric validation of critical fields, per-file critical missing counters, dropped-row reason accounting, and richer `LoadDiagnostics` fields (`dropped_by_reason`, `critical_missing_counts`). (`src/data_loader.py`).
- Added diagnostics export writer `write_diagnostics` that emits `diagnostics.tsv` with counters, drop reasons, and missing-field counts. (`src/reporting.py`).
- Wired a CLI `--strict` flag into the main orchestrator and ensured diagnostics are written during normal runs. (`src/playoff_draft.py`).
- Expanded test coverage to assert strict vs non-strict parsing behavior and the diagnostics file contents, including a new `tests/test_reporting.py` and updates to `tests/test_data_loader.py`.

### Testing
- Ran the main pipeline with `python src/playoff_draft.py`, which completed and printed the diagnostics summary and `SUCCESS` (diagnostics were written to `out/season_2026/diagnostics.tsv`).
- Ran the test suite with `pytest -q` and all automated tests passed (`22 passed`).
- New and updated tests exercising strict/non-strict ingest behavior and diagnostics output succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19f5262008329b9e5f84995c9f0bb)