### PR TITLE
Implement Section 8 tuning workflow, manifest, and convergence outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project currently provides:
 - typed projection contracts and scoring helpers,
 - lineup optimization under exact roster constraints (5F / 3D / 2 goalie teams),
 - a backtesting/calibration harness across historical seasons and parameter grids,
+- a two-stage tuning harness (coarse sweep + local refinement) with run lineage output,
 - ranked output exports for downstream draft decisions.
 
 ---
@@ -39,6 +40,7 @@ At a high level, the pipeline:
 6. Selects a lineup under roster constraints.
 7. Writes ranked TSV outputs to `out/season_2026`.
 8. Optionally runs historical backtests and writes metrics to `out/backtest`.
+9. Optionally runs iterative tuning and writes search lineage to `out/tuning`.
 
 The current optimizer is intentionally simple (greedy by projected value) and is planned to be replaced by a constrained optimization model in a follow-up phase.
 
@@ -224,6 +226,16 @@ Expected files under `--realized-root`:
 Backtesting outputs:
 - `out/backtest/summary.tsv`
 - `out/backtest/season_<year>_details.tsv`
+
+Run the tuning harness:
+
+```bash
+python scripts/tune.py --seasons 2024 2025
+```
+
+Tuning outputs:
+- `out/tuning/runs.tsv` (timestamp, git commit, config ID, stage, parent run lineage, runtime, and metrics)
+- `out/tuning/candidates.tsv` (top converged candidate configs that pass baseline gates)
 
 ---
 

--- a/docs/heuristics_implementation_plan.md
+++ b/docs/heuristics_implementation_plan.md
@@ -284,6 +284,52 @@ For each candidate include:
 
 ---
 
+## 8) Tuning + convergence strategy
+
+### Objective
+Systematically tune heuristics/method/config values through iterative backtests so we fit recent seasons well enough to improve 2026 predictive quality, while converging quickly toward a strong parameter valley.
+
+### Implementation details
+
+#### 8.1 Tunable parameter space
+Define a single tuning manifest in `src/config.py` (or `configs/tuning_grid.yaml`) that includes:
+- model method toggles (analytic vs Monte Carlo expected games)
+- shrinkage params (`STRETCH_SHRINKAGE_K`, minimum stretch GP threshold)
+- risk controls (`risk_lambda`, exposure/team-cap constraints)
+- series length assumptions (`E_LEN_R1..R4`) and any weighting knobs
+
+Keep defaults as the current production baseline, and version each experiment config with a stable ID.
+
+#### 8.2 Iterative search workflow
+Add `scripts/tune.py` orchestrating repeated backtests with two stages:
+1. **Coarse sweep** over broad ranges to locate promising regions.
+2. **Local refinement** around top candidates using narrower ranges/smaller step sizes.
+
+Persist all runs to `out/tuning/runs.tsv` with:
+- timestamp, git commit, config ID, season set, metrics, runtime
+- parent run ID (for refinement lineage)
+
+#### 8.3 Fast-convergence tactics
+- Start with low-cost approximations (fewer MC sims, reduced grids), then increase fidelity near best regions.
+- Use early-pruning rules: stop evaluating configs that are clearly dominated after first season split.
+- Cache reusable intermediate outputs per season/method to avoid recomputing full projections.
+- Use rolling validation splits (e.g., tune on 2024, validate on 2025; then swap/check combined stability) to avoid overfitting one year.
+
+#### 8.4 Selection criteria for 2026
+Pick final settings using a weighted score that rewards:
+- strong out-of-sample lineup performance vs baseline
+- stable rank quality across seasons/positions
+- low variance across validation splits
+
+Promote only configs that beat baseline on predeclared primary metrics (not just one-off best score).
+
+### Acceptance criteria
+- Single reproducible command runs coarse + refinement tuning and records lineage.
+- Tuning report identifies a small set of converged candidate configs with clear tradeoffs.
+- Final chosen 2026 config is justified by out-of-sample results, not in-sample best fit alone.
+
+---
+
 ## Sequential stacked-branch workflow (no Graphite; branch prefix `codex/improveHeuristics/`)
 
 Each task ships on its own branch, each branch based on previous branch head.
@@ -295,6 +341,7 @@ Each task ships on its own branch, each branch based on previous branch head.
 5. `codex/improveHeuristics/data-reliability` (base: `codex/improveHeuristics/optimizer`)
 6. `codex/improveHeuristics/backtesting` (base: `codex/improveHeuristics/data-reliability`)
 7. `codex/improveHeuristics/reporting` (base: `codex/improveHeuristics/backtesting`)
+8. `codex/improveHeuristics/tuning` (base: `codex/improveHeuristics/reporting`)
 
 ### Per-branch execution checklist
 - Implement only scoped files/functions for the branch.

--- a/scripts/tune.py
+++ b/scripts/tune.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+import time
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from backtesting import SeasonBacktestResult, run_season_backtest
+from config import TUNING_BASELINE, TUNING_GRID, TuningConfig
+from tuning import TuningScore, passes_primary_metric_gate, weighted_validation_score
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Tune playoff drafter heuristics with coarse sweep + local refinement.")
+    parser.add_argument("--seasons", nargs="+", type=int, required=True, help="Backtest seasons, e.g. 2024 2025")
+    parser.add_argument("--coarse-limit", type=int, default=None, help="Optional cap on number of coarse configs")
+    parser.add_argument("--refine-top-k", type=int, default=TUNING_GRID.refinement_top_k)
+    parser.add_argument("--prune-margin", type=float, default=0.75, help="Early-pruning margin vs best split score")
+    parser.add_argument("--realized-root", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _git_commit() -> str:
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=ROOT, text=True)
+            .strip()
+        )
+    except Exception:
+        return "unknown"
+
+
+def _rolling_validation_splits(seasons: list[int]) -> list[tuple[list[int], list[int]]]:
+    if len(seasons) < 2:
+        return [(seasons, seasons)]
+
+    splits: list[tuple[list[int], list[int]]] = []
+    for idx in range(len(seasons)):
+        validation = [seasons[idx]]
+        train = [season for i, season in enumerate(seasons) if i != idx]
+        splits.append((train, validation))
+    return splits
+
+
+def _coarse_configs() -> list[TuningConfig]:
+    configs: list[TuningConfig] = []
+    for method in TUNING_GRID.methods:
+        mc_sims = TUNING_GRID.coarse_monte_carlo_simulations if method == "monte_carlo" else TUNING_BASELINE.monte_carlo_simulations
+        for shrinkage_k in TUNING_GRID.shrinkage_k_values:
+            for min_stretch_gp in TUNING_GRID.min_stretch_gp_values:
+                for risk_lambda in TUNING_GRID.risk_lambda_values:
+                    for max_skaters in TUNING_GRID.max_skaters_per_team_values:
+                        for max_total in TUNING_GRID.max_total_from_team_values:
+                            if max_skaters is not None and max_total is not None and max_total < max_skaters:
+                                continue
+                            for series_profile in TUNING_GRID.series_length_profiles:
+                                configs.append(
+                                    TuningConfig(
+                                        method=method,
+                                        stretch_shrinkage_k=shrinkage_k,
+                                        min_stretch_gp_for_direct_weight=min_stretch_gp,
+                                        risk_lambda=risk_lambda,
+                                        max_skaters_per_team=max_skaters,
+                                        max_total_from_team_including_goalie_team=max_total,
+                                        series_lengths=series_profile,
+                                        monte_carlo_simulations=mc_sims,
+                                    )
+                                )
+    return sorted(configs, key=lambda config: config.stable_id())
+
+
+def _refined_neighbors(config: TuningConfig) -> list[TuningConfig]:
+    refined: dict[str, TuningConfig] = {}
+    for dk in (-5, 5):
+        refined_cfg = replace(config, stretch_shrinkage_k=max(5, config.stretch_shrinkage_k + dk))
+        refined[refined_cfg.stable_id()] = refined_cfg
+
+    for dgp in (-2, 2):
+        refined_cfg = replace(
+            config,
+            min_stretch_gp_for_direct_weight=max(2, config.min_stretch_gp_for_direct_weight + dgp),
+        )
+        refined[refined_cfg.stable_id()] = refined_cfg
+
+    for drisk in (-0.05, 0.05):
+        refined_cfg = replace(config, risk_lambda=round(max(-0.5, min(0.75, config.risk_lambda + drisk)), 3))
+        refined[refined_cfg.stable_id()] = refined_cfg
+
+    for dsl in (-0.1, 0.1):
+        refined_cfg = replace(
+            config,
+            series_lengths=replace(
+                config.series_lengths,
+                round1=max(5.0, min(6.4, config.series_lengths.round1 + dsl)),
+                round2=max(5.0, min(6.4, config.series_lengths.round2 + dsl)),
+                round3=max(5.0, min(6.4, config.series_lengths.round3 + dsl)),
+                round4=max(5.0, min(6.4, config.series_lengths.round4 + dsl)),
+            ),
+        )
+        refined[refined_cfg.stable_id()] = refined_cfg
+
+    for max_skaters in (None, 3):
+        refined_cfg = replace(config, max_skaters_per_team=max_skaters)
+        if (
+            refined_cfg.max_skaters_per_team is None
+            or refined_cfg.max_total_from_team_including_goalie_team is None
+            or refined_cfg.max_total_from_team_including_goalie_team >= refined_cfg.max_skaters_per_team
+        ):
+            refined[refined_cfg.stable_id()] = refined_cfg
+
+    for max_total in (None, 3, 4):
+        refined_cfg = replace(config, max_total_from_team_including_goalie_team=max_total)
+        if (
+            refined_cfg.max_skaters_per_team is None
+            or refined_cfg.max_total_from_team_including_goalie_team is None
+            or refined_cfg.max_total_from_team_including_goalie_team >= refined_cfg.max_skaters_per_team
+        ):
+            refined[refined_cfg.stable_id()] = refined_cfg
+
+    for stable_id, candidate in list(refined.items()):
+        if candidate.method == "monte_carlo":
+            refined[stable_id] = replace(candidate, monte_carlo_simulations=TUNING_GRID.refine_monte_carlo_simulations)
+    return sorted(refined.values(), key=lambda item: item.stable_id())
+
+
+def _evaluate_config(
+    config: TuningConfig,
+    seasons: list[int],
+    prune_margin: float,
+    realized_root: Path | None,
+    split_baseline_best: dict[int, float],
+    season_cache: dict[tuple[int, str], SeasonBacktestResult],
+) -> tuple[TuningScore, list[SeasonBacktestResult]]:
+    split_scores: list[float] = []
+    split_lineup_deltas: list[float] = []
+    split_spearman: list[float] = []
+    split_rmse: list[float] = []
+    season_results: list[SeasonBacktestResult] = []
+
+    splits = _rolling_validation_splits(seasons)
+
+    for split_idx, (_, validation_seasons) in enumerate(splits):
+        split_values: list[float] = []
+        for season in validation_seasons:
+            cache_key = (season, config.stable_id())
+            if cache_key in season_cache:
+                result = season_cache[cache_key]
+            else:
+                result = run_season_backtest(
+                    root_dir=ROOT,
+                    season=season,
+                    method=config.method,
+                    shrinkage_k=config.stretch_shrinkage_k,
+                    risk_lambda=config.risk_lambda,
+                    min_stretch_gp_for_direct_weight=config.min_stretch_gp_for_direct_weight,
+                    max_skaters_per_team=config.max_skaters_per_team,
+                    max_total_from_team_including_goalie_team=config.max_total_from_team_including_goalie_team,
+                    series_len_r1=config.series_lengths.round1,
+                    series_len_r2=config.series_lengths.round2,
+                    series_len_r3=config.series_lengths.round3,
+                    series_len_r4=config.series_lengths.round4,
+                    monte_carlo_simulations=config.monte_carlo_simulations,
+                    realized_root_dir=realized_root,
+                )
+                season_cache[cache_key] = result
+            season_results.append(result)
+
+            lineup_delta = result.optimized_lineup_realized - result.baseline_lineup_realized
+            score = weighted_validation_score(
+                lineup_delta=lineup_delta,
+                spearman=result.overall.spearman,
+                rmse=result.overall.rmse,
+            )
+            split_values.append(score)
+            split_lineup_deltas.append(lineup_delta)
+            split_spearman.append(result.overall.spearman)
+            split_rmse.append(result.overall.rmse)
+
+        split_score = sum(split_values) / len(split_values)
+        split_scores.append(split_score)
+
+        current_best = split_baseline_best.get(split_idx, float("-inf"))
+        if split_score > current_best:
+            split_baseline_best[split_idx] = split_score
+        elif split_score < current_best - prune_margin:
+            break
+
+    if not split_scores:
+        split_scores = [-1e9]
+
+    score = TuningScore(
+        config=config,
+        mean_weighted_score=sum(split_scores) / len(split_scores),
+        min_weighted_score=min(split_scores),
+        mean_lineup_delta=(sum(split_lineup_deltas) / len(split_lineup_deltas)) if split_lineup_deltas else -1e9,
+        mean_spearman=(sum(split_spearman) / len(split_spearman)) if split_spearman else -1e9,
+        mean_rmse=(sum(split_rmse) / len(split_rmse)) if split_rmse else 1e9,
+    )
+    return score, season_results
+
+
+def _write_runs(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            delimiter="\t",
+            fieldnames=[
+                "timestamp_utc",
+                "git_commit",
+                "run_id",
+                "parent_run_id",
+                "stage",
+                "season_set",
+                "config_id",
+                "method",
+                "k",
+                "min_stretch_gp",
+                "risk_lambda",
+                "max_skaters_per_team",
+                "max_total_from_team",
+                "series_lengths",
+                "mc_simulations",
+                "mean_weighted_score",
+                "min_weighted_score",
+                "mean_lineup_delta",
+                "mean_spearman",
+                "mean_rmse",
+                "runtime_sec",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_candidates(path: Path, top_scores: list[TuningScore]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(
+            [
+                "config_id",
+                "method",
+                "k",
+                "min_stretch_gp",
+                "risk_lambda",
+                "max_skaters_per_team",
+                "max_total_from_team",
+                "series_lengths",
+                "mean_weighted_score",
+                "min_weighted_score",
+                "mean_lineup_delta",
+                "mean_spearman",
+                "mean_rmse",
+            ]
+        )
+        for score in top_scores:
+            config = score.config
+            writer.writerow(
+                [
+                    config.stable_id(),
+                    config.method,
+                    config.stretch_shrinkage_k,
+                    config.min_stretch_gp_for_direct_weight,
+                    f"{config.risk_lambda:.3f}",
+                    "" if config.max_skaters_per_team is None else config.max_skaters_per_team,
+                    "" if config.max_total_from_team_including_goalie_team is None else config.max_total_from_team_including_goalie_team,
+                    f"{config.series_lengths.round1:.2f},{config.series_lengths.round2:.2f},{config.series_lengths.round3:.2f},{config.series_lengths.round4:.2f}",
+                    f"{score.mean_weighted_score:.6f}",
+                    f"{score.min_weighted_score:.6f}",
+                    f"{score.mean_lineup_delta:.6f}",
+                    f"{score.mean_spearman:.6f}",
+                    f"{score.mean_rmse:.6f}",
+                ]
+            )
+
+
+def main() -> None:
+    args = parse_args()
+    seasons = sorted(dict.fromkeys(args.seasons))
+    season_set = ",".join(str(year) for year in seasons)
+    git_commit = _git_commit()
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    season_cache: dict[tuple[int, str], SeasonBacktestResult] = {}
+    split_baseline_best: dict[int, float] = {}
+    all_rows: list[dict[str, str]] = []
+
+    coarse_configs = _coarse_configs()
+    if args.coarse_limit is not None:
+        coarse_configs = coarse_configs[: args.coarse_limit]
+
+    coarse_scores: list[TuningScore] = []
+    run_counter = 0
+    for config in coarse_configs:
+        start = time.perf_counter()
+        score, _ = _evaluate_config(
+            config=config,
+            seasons=seasons,
+            prune_margin=args.prune_margin,
+            realized_root=args.realized_root,
+            split_baseline_best=split_baseline_best,
+            season_cache=season_cache,
+        )
+        runtime_sec = time.perf_counter() - start
+        coarse_scores.append(score)
+
+        run_counter += 1
+        all_rows.append(
+            {
+                "timestamp_utc": timestamp,
+                "git_commit": git_commit,
+                "run_id": f"run-{run_counter:05d}",
+                "parent_run_id": "",
+                "stage": "coarse",
+                "season_set": season_set,
+                "config_id": config.stable_id(),
+                "method": config.method,
+                "k": str(config.stretch_shrinkage_k),
+                "min_stretch_gp": str(config.min_stretch_gp_for_direct_weight),
+                "risk_lambda": f"{config.risk_lambda:.3f}",
+                "max_skaters_per_team": "" if config.max_skaters_per_team is None else str(config.max_skaters_per_team),
+                "max_total_from_team": (
+                    ""
+                    if config.max_total_from_team_including_goalie_team is None
+                    else str(config.max_total_from_team_including_goalie_team)
+                ),
+                "series_lengths": (
+                    f"{config.series_lengths.round1:.2f},{config.series_lengths.round2:.2f},"
+                    f"{config.series_lengths.round3:.2f},{config.series_lengths.round4:.2f}"
+                ),
+                "mc_simulations": str(config.monte_carlo_simulations),
+                "mean_weighted_score": f"{score.mean_weighted_score:.6f}",
+                "min_weighted_score": f"{score.min_weighted_score:.6f}",
+                "mean_lineup_delta": f"{score.mean_lineup_delta:.6f}",
+                "mean_spearman": f"{score.mean_spearman:.6f}",
+                "mean_rmse": f"{score.mean_rmse:.6f}",
+                "runtime_sec": f"{runtime_sec:.3f}",
+            }
+        )
+
+    coarse_scores = sorted(coarse_scores, key=lambda item: (item.mean_weighted_score, item.min_weighted_score), reverse=True)
+    coarse_best = coarse_scores[: TUNING_GRID.coarse_top_k]
+
+    refined_scores: list[TuningScore] = []
+    for parent in coarse_best:
+        for config in _refined_neighbors(parent.config):
+            start = time.perf_counter()
+            score, _ = _evaluate_config(
+                config=config,
+                seasons=seasons,
+                prune_margin=args.prune_margin,
+                realized_root=args.realized_root,
+                split_baseline_best=split_baseline_best,
+                season_cache=season_cache,
+            )
+            runtime_sec = time.perf_counter() - start
+            refined_scores.append(score)
+
+            run_counter += 1
+            all_rows.append(
+                {
+                    "timestamp_utc": timestamp,
+                    "git_commit": git_commit,
+                    "run_id": f"run-{run_counter:05d}",
+                    "parent_run_id": parent.config.stable_id(),
+                    "stage": "refine",
+                    "season_set": season_set,
+                    "config_id": config.stable_id(),
+                    "method": config.method,
+                    "k": str(config.stretch_shrinkage_k),
+                    "min_stretch_gp": str(config.min_stretch_gp_for_direct_weight),
+                    "risk_lambda": f"{config.risk_lambda:.3f}",
+                    "max_skaters_per_team": "" if config.max_skaters_per_team is None else str(config.max_skaters_per_team),
+                    "max_total_from_team": (
+                        ""
+                        if config.max_total_from_team_including_goalie_team is None
+                        else str(config.max_total_from_team_including_goalie_team)
+                    ),
+                    "series_lengths": (
+                        f"{config.series_lengths.round1:.2f},{config.series_lengths.round2:.2f},"
+                        f"{config.series_lengths.round3:.2f},{config.series_lengths.round4:.2f}"
+                    ),
+                    "mc_simulations": str(config.monte_carlo_simulations),
+                    "mean_weighted_score": f"{score.mean_weighted_score:.6f}",
+                    "min_weighted_score": f"{score.min_weighted_score:.6f}",
+                    "mean_lineup_delta": f"{score.mean_lineup_delta:.6f}",
+                    "mean_spearman": f"{score.mean_spearman:.6f}",
+                    "mean_rmse": f"{score.mean_rmse:.6f}",
+                    "runtime_sec": f"{runtime_sec:.3f}",
+                }
+            )
+
+    combined_scores = coarse_scores + refined_scores
+    combined_scores = [
+        item
+        for item in combined_scores
+        if passes_primary_metric_gate([item.mean_lineup_delta], [item.mean_spearman])
+    ]
+    combined_scores = sorted(combined_scores, key=lambda item: (item.mean_weighted_score, item.min_weighted_score), reverse=True)
+    final_candidates = combined_scores[: args.refine_top_k]
+
+    out_dir = ROOT / "out" / "tuning"
+    _write_runs(out_dir / "runs.tsv", all_rows)
+    _write_candidates(out_dir / "candidates.tsv", final_candidates)
+
+    print(f"Wrote {out_dir / 'runs.tsv'}")
+    print(f"Wrote {out_dir / 'candidates.tsv'}")
+    if final_candidates:
+        winner = final_candidates[0]
+        print(f"Best config: {winner.config.stable_id()} score={winner.mean_weighted_score:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backtesting.py
+++ b/src/backtesting.py
@@ -280,6 +280,14 @@ def run_season_backtest(
     method: str,
     shrinkage_k: int,
     risk_lambda: float,
+    min_stretch_gp_for_direct_weight: int = 10,
+    max_skaters_per_team: int | None = None,
+    max_total_from_team_including_goalie_team: int | None = None,
+    series_len_r1: float = 5.9,
+    series_len_r2: float = 5.9,
+    series_len_r3: float = 5.9,
+    series_len_r4: float = 5.9,
+    monte_carlo_simulations: int = 20_000,
     realized_root_dir: Path | None = None,
 ) -> SeasonBacktestResult:
     resources_dir = root_dir / "resources" / str(season)
@@ -304,13 +312,22 @@ def run_season_backtest(
     set_team_estimated_values(teams, players, heuristics.get_team_weight_diff_penalty)
     set_player_estimated_values(players, heuristics.sum_team_odds_multiply_points_stretch_weighted_per_game)
 
-    expected_games = estimate_expected_games(loader.to_team_odds_inputs(teams), method=method)
+    expected_games = estimate_expected_games(
+        loader.to_team_odds_inputs(teams),
+        method=method,
+        monte_carlo_simulations=monte_carlo_simulations,
+        series_len_r1=series_len_r1,
+        series_len_r2=series_len_r2,
+        series_len_r3=series_len_r3,
+        series_len_r4=series_len_r4,
+    )
     expected_team_games = {team_name: stats.mean for team_name, stats in expected_games.items()}
 
     skater_projections = project_skaters(
         loader.to_skater_projection_inputs(players),
         expected_team_games,
         stretch_shrinkage_k=shrinkage_k,
+        min_stretch_gp_for_direct_weight=min_stretch_gp_for_direct_weight,
     )
     goalie_projections = project_goalie_teams(loader.to_goalie_team_projection_inputs(teams), expected_team_games)
 
@@ -318,7 +335,13 @@ def run_season_backtest(
         forwards=[item for item in skater_projections if item.position == "F"],
         defense=[item for item in skater_projections if item.position == "D"],
         goalie_teams=goalie_projections,
-        constraints=LineupConstraints(forwards=ROSTER.forwards, defense=ROSTER.defense, goalie_teams=ROSTER.goalie_teams),
+        constraints=LineupConstraints(
+            forwards=ROSTER.forwards,
+            defense=ROSTER.defense,
+            goalie_teams=ROSTER.goalie_teams,
+            max_skaters_per_team=max_skaters_per_team,
+            max_total_from_team_including_goalie_team=max_total_from_team_including_goalie_team,
+        ),
         risk_lambda=risk_lambda,
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from hashlib import sha1
 from pathlib import Path
 
 
@@ -17,6 +18,52 @@ class RosterConfig:
     forwards: int = 5
     defense: int = 3
     goalie_teams: int = 2
+
+
+@dataclass(frozen=True)
+class SeriesLengthConfig:
+    round1: float = 5.9
+    round2: float = 5.9
+    round3: float = 5.9
+    round4: float = 5.9
+
+
+@dataclass(frozen=True)
+class TuningConfig:
+    method: str
+    stretch_shrinkage_k: int
+    min_stretch_gp_for_direct_weight: int
+    risk_lambda: float
+    max_skaters_per_team: int | None
+    max_total_from_team_including_goalie_team: int | None
+    series_lengths: SeriesLengthConfig
+    monte_carlo_simulations: int
+
+    def stable_id(self) -> str:
+        payload = (
+            f"m={self.method}|k={self.stretch_shrinkage_k}|min_gp={self.min_stretch_gp_for_direct_weight}|"
+            f"risk={self.risk_lambda:.4f}|max_skaters={self.max_skaters_per_team}|"
+            f"max_total={self.max_total_from_team_including_goalie_team}|"
+            f"series={self.series_lengths.round1:.2f},{self.series_lengths.round2:.2f},"
+            f"{self.series_lengths.round3:.2f},{self.series_lengths.round4:.2f}|"
+            f"mc={self.monte_carlo_simulations}"
+        )
+        return sha1(payload.encode("utf-8")).hexdigest()[:12]
+
+
+@dataclass(frozen=True)
+class TuningGrid:
+    methods: tuple[str, ...]
+    shrinkage_k_values: tuple[int, ...]
+    min_stretch_gp_values: tuple[int, ...]
+    risk_lambda_values: tuple[float, ...]
+    max_skaters_per_team_values: tuple[int | None, ...]
+    max_total_from_team_values: tuple[int | None, ...]
+    series_length_profiles: tuple[SeriesLengthConfig, ...]
+    coarse_monte_carlo_simulations: int
+    refine_monte_carlo_simulations: int
+    coarse_top_k: int
+    refinement_top_k: int
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -40,3 +87,39 @@ EXPECTED_SERIES_LENGTH_R1 = 5.9
 EXPECTED_SERIES_LENGTH_R2 = 5.9
 EXPECTED_SERIES_LENGTH_R3 = 5.9
 EXPECTED_SERIES_LENGTH_R4 = 5.9
+
+DEFAULT_SERIES_LENGTHS = SeriesLengthConfig(
+    round1=EXPECTED_SERIES_LENGTH_R1,
+    round2=EXPECTED_SERIES_LENGTH_R2,
+    round3=EXPECTED_SERIES_LENGTH_R3,
+    round4=EXPECTED_SERIES_LENGTH_R4,
+)
+
+TUNING_BASELINE = TuningConfig(
+    method=EXPECTED_GAMES_METHOD,
+    stretch_shrinkage_k=STRETCH_SHRINKAGE_K,
+    min_stretch_gp_for_direct_weight=MIN_STRETCH_GP_FOR_DIRECT_WEIGHT,
+    risk_lambda=0.0,
+    max_skaters_per_team=None,
+    max_total_from_team_including_goalie_team=None,
+    series_lengths=DEFAULT_SERIES_LENGTHS,
+    monte_carlo_simulations=EXPECTED_GAMES_MONTE_CARLO_SIMULATIONS,
+)
+
+TUNING_GRID = TuningGrid(
+    methods=("analytic", "monte_carlo"),
+    shrinkage_k_values=(10, 20, 30, 40),
+    min_stretch_gp_values=(6, 10, 14),
+    risk_lambda_values=(0.0, 0.1, 0.2),
+    max_skaters_per_team_values=(None, 3),
+    max_total_from_team_values=(None, 3, 4),
+    series_length_profiles=(
+        DEFAULT_SERIES_LENGTHS,
+        SeriesLengthConfig(round1=5.7, round2=5.8, round3=5.9, round4=6.0),
+        SeriesLengthConfig(round1=6.0, round2=6.0, round3=6.1, round4=6.1),
+    ),
+    coarse_monte_carlo_simulations=3000,
+    refine_monte_carlo_simulations=20000,
+    coarse_top_k=8,
+    refinement_top_k=3,
+)

--- a/src/models.py
+++ b/src/models.py
@@ -99,6 +99,42 @@ def expected_games_analytic(team_odds: TeamOddsInput) -> ExpectedGamesResult:
     return ExpectedGamesResult(mean=expected_games, std=std, p10=p10, p90=p90)
 
 
+def expected_games_analytic_with_series_lengths(
+    team_odds: TeamOddsInput,
+    series_len_r1: float,
+    series_len_r2: float,
+    series_len_r3: float,
+    series_len_r4: float,
+) -> ExpectedGamesResult:
+    p1, p2, p3, _ = _independent_round_probabilities(team_odds)
+    q2 = p1
+    q3 = p1 * p2
+    q4 = p1 * p2 * p3
+
+    expected_games = (
+        series_len_r1
+        + (q2 * series_len_r2)
+        + (q3 * series_len_r3)
+        + (q4 * series_len_r4)
+    )
+
+    variance = (
+        (series_len_r2**2) * q2 * (1.0 - q2)
+        + (series_len_r3**2) * q3 * (1.0 - q3)
+        + (series_len_r4**2) * q4 * (1.0 - q4)
+        + (2.0 * series_len_r2 * series_len_r3 * q3 * (1.0 - q2))
+        + (2.0 * series_len_r2 * series_len_r4 * q4 * (1.0 - q2))
+        + (2.0 * series_len_r3 * series_len_r4 * q4 * (1.0 - q3))
+    )
+    std = math.sqrt(max(0.0, variance))
+    spread = 1.28155 * std
+    max_total = series_len_r1 + series_len_r2 + series_len_r3 + series_len_r4
+    p10 = max(series_len_r1, expected_games - spread)
+    p90 = min(max_total, expected_games + spread)
+
+    return ExpectedGamesResult(mean=expected_games, std=std, p10=p10, p90=p90)
+
+
 def _sample_series_length(rand: random.Random) -> int:
     # Lightweight empirical prior for playoff series length.
     roll = rand.random()
@@ -165,16 +201,33 @@ def expected_games_monte_carlo(
 def estimate_expected_games(
     team_odds_inputs: list[TeamOddsInput],
     method: str = EXPECTED_GAMES_METHOD,
+    monte_carlo_simulations: int = EXPECTED_GAMES_MONTE_CARLO_SIMULATIONS,
+    series_len_r1: float = EXPECTED_SERIES_LENGTH_R1,
+    series_len_r2: float = EXPECTED_SERIES_LENGTH_R2,
+    series_len_r3: float = EXPECTED_SERIES_LENGTH_R3,
+    series_len_r4: float = EXPECTED_SERIES_LENGTH_R4,
 ) -> dict[str, ExpectedGamesResult]:
     results: dict[str, ExpectedGamesResult] = {}
     for item in team_odds_inputs:
         if method == "monte_carlo":
             try:
-                result = expected_games_monte_carlo(item)
+                result = expected_games_monte_carlo(item, simulations=monte_carlo_simulations)
             except Exception:
-                result = expected_games_analytic(item)
+                result = expected_games_analytic_with_series_lengths(
+                    item,
+                    series_len_r1=series_len_r1,
+                    series_len_r2=series_len_r2,
+                    series_len_r3=series_len_r3,
+                    series_len_r4=series_len_r4,
+                )
         else:
-            result = expected_games_analytic(item)
+            result = expected_games_analytic_with_series_lengths(
+                item,
+                series_len_r1=series_len_r1,
+                series_len_r2=series_len_r2,
+                series_len_r3=series_len_r3,
+                series_len_r4=series_len_r4,
+            )
         results[item.team] = result
     return results
 

--- a/src/tuning.py
+++ b/src/tuning.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config import TuningConfig
+
+
+@dataclass(frozen=True)
+class TuningScore:
+    config: TuningConfig
+    mean_weighted_score: float
+    min_weighted_score: float
+    mean_lineup_delta: float
+    mean_spearman: float
+    mean_rmse: float
+
+
+def weighted_validation_score(*, lineup_delta: float, spearman: float, rmse: float) -> float:
+    return (0.60 * lineup_delta) + (0.35 * spearman) - (0.05 * rmse)
+
+
+def passes_primary_metric_gate(lineup_delta_values: list[float], spearman_values: list[float]) -> bool:
+    if not lineup_delta_values or not spearman_values:
+        return False
+    return min(lineup_delta_values) > 0 and (sum(spearman_values) / len(spearman_values)) >= 0.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from config import (
+    DEFAULT_SERIES_LENGTHS,
     EXPECTED_GAMES_METHOD,
     EXPECTED_GAMES_MONTE_CARLO_SIMULATIONS,
     EXPECTED_SERIES_LENGTH_R1,
@@ -15,6 +16,8 @@ from config import (
     ROSTER,
     SCORING,
     STRETCH_SHRINKAGE_K,
+    TUNING_BASELINE,
+    TUNING_GRID,
 )
 
 
@@ -43,6 +46,14 @@ class ConfigDefaultsTests(unittest.TestCase):
         self.assertEqual(EXPECTED_SERIES_LENGTH_R2, 5.9)
         self.assertEqual(EXPECTED_SERIES_LENGTH_R3, 5.9)
         self.assertEqual(EXPECTED_SERIES_LENGTH_R4, 5.9)
+
+    def test_tuning_manifest_defaults(self):
+        self.assertEqual(TUNING_BASELINE.method, EXPECTED_GAMES_METHOD)
+        self.assertEqual(TUNING_BASELINE.stretch_shrinkage_k, STRETCH_SHRINKAGE_K)
+        self.assertEqual(TUNING_BASELINE.min_stretch_gp_for_direct_weight, MIN_STRETCH_GP_FOR_DIRECT_WEIGHT)
+        self.assertEqual(TUNING_BASELINE.series_lengths, DEFAULT_SERIES_LENGTHS)
+        self.assertGreater(len(TUNING_GRID.methods), 0)
+        self.assertGreater(len(TUNING_GRID.series_length_profiles), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -1,0 +1,45 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from config import DEFAULT_SERIES_LENGTHS, TuningConfig
+from tuning import passes_primary_metric_gate, weighted_validation_score
+
+
+class TuningHelpersTests(unittest.TestCase):
+    def test_weighted_validation_score(self):
+        score = weighted_validation_score(lineup_delta=4.0, spearman=0.5, rmse=2.0)
+        self.assertAlmostEqual(score, 2.475)
+
+    def test_primary_metric_gate(self):
+        self.assertTrue(passes_primary_metric_gate([0.1, 0.2], [0.0, 0.4]))
+        self.assertFalse(passes_primary_metric_gate([-0.1, 0.2], [0.1, 0.2]))
+
+    def test_tuning_config_stable_id(self):
+        a = TuningConfig(
+            method="analytic",
+            stretch_shrinkage_k=20,
+            min_stretch_gp_for_direct_weight=10,
+            risk_lambda=0.1,
+            max_skaters_per_team=3,
+            max_total_from_team_including_goalie_team=4,
+            series_lengths=DEFAULT_SERIES_LENGTHS,
+            monte_carlo_simulations=20000,
+        )
+        b = TuningConfig(
+            method="analytic",
+            stretch_shrinkage_k=20,
+            min_stretch_gp_for_direct_weight=10,
+            risk_lambda=0.1,
+            max_skaters_per_team=3,
+            max_total_from_team_including_goalie_team=4,
+            series_lengths=DEFAULT_SERIES_LENGTHS,
+            monte_carlo_simulations=20000,
+        )
+        self.assertEqual(a.stable_id(), b.stable_id())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make the planning text in Section 8 executable by adding a reproducible tuning harness to search and converge on heuristic/config settings. 
- Enable tuning to vary key modeling knobs (expected-games method, series-length assumptions, MC fidelity, shrinkage, risk/exposure caps) so backtests can evaluate realistic variants end-to-end. 
- Support fast-convergence tactics (coarse sweep → local refinement, caching, early pruning, rolling validation) and record lineage so results are auditable and repeatable.

### Description
- Add a unified tuning manifest and types in `src/config.py` (`TuningConfig`, `TuningGrid`, `SeriesLengthConfig`, `TUNING_BASELINE`, `TUNING_GRID`) and stable config IDs via `stable_id()` so experiments are versioned. 
- Extend expected-games modeling to accept per-run series-length overrides and MC simulation counts in `src/models.py` and expose those knobs via `estimate_expected_games(...)`. 
- Extend backtest plumbing in `src/backtesting.py` so `run_season_backtest(...)` accepts tuning knobs (min stretch GP, exposure caps, series-length values, MC sims) and propagates them through projection and optimizer paths. 
- Implement the two-stage tuning driver `scripts/tune.py` that runs a coarse sweep, performs local refinement around top candidates, uses rolling validation splits, per-season/config caching, early-pruning by split score, and writes lineage+metrics to `out/tuning/runs.tsv` and top candidates to `out/tuning/candidates.tsv`. 
- Add `src/tuning.py` with reusable scoring and gating helpers (`weighted_validation_score`, `passes_primary_metric_gate`) and corresponding unit tests. 
- Update `README.md` and `docs/heuristics_implementation_plan.md` to document the tuning workflow and outputs. 
- Add/adjust unit tests: `tests/test_tuning.py` for tuning helpers and extended assertions in `tests/test_config.py` to cover the tuning manifest.

### Testing
- Ran unit test suite with `pytest -q`; all tests passed: `32 passed`. 
- Verified CLI/help for tuning with `python scripts/tune.py --help` (prints usage). 
- Executed a quick tuning invocation `python scripts/tune.py --seasons 2024 2025 --coarse-limit 0 --refine-top-k 2`, which completed and wrote `out/tuning/runs.tsv` and `out/tuning/candidates.tsv` (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ab48d7248329a490c7470bbb4f23)